### PR TITLE
Allow users to override the install directory using an env variable at runtime

### DIFF
--- a/src/logger.zig
+++ b/src/logger.zig
@@ -3,32 +3,32 @@ const std = @import("std");
 var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
 var allocator = &arena.allocator;
 
-pub fn query(comptime message: []const u8, args: anytype) anyerror!void {
+pub fn query(comptime message: []const u8, args: anytype) void {
     var stdout = std.io.getStdOut().writer();
-    var out_string = try std.fmt.allocPrint(allocator, message, args);
-    try stdout.print("[?] {s}", .{out_string});
+    var out_string = std.fmt.allocPrint(allocator, message, args);
+    stdout.print("[?] {s}", .{out_string}) catch {};
 }
 
-pub fn info(comptime message: []const u8, args: anytype) anyerror!void {
+pub fn info(comptime message: []const u8, args: anytype) void {
     var stdout = std.io.getStdOut().writer();
-    var out_string = try std.fmt.allocPrint(allocator, message, args);
-    try stdout.print("[i] {s}\n", .{out_string});
+    var out_string = std.fmt.allocPrint(allocator, message, args);
+    stdout.print("[i] {s}\n", .{out_string}) catch {};
 }
 
-pub fn warn(comptime message: []const u8, args: anytype) anyerror!void {
+pub fn warn(comptime message: []const u8, args: anytype) void {
     var stderr = std.io.getStdErr().writer();
-    var out_string = try std.fmt.allocPrint(allocator, message, args);
-    try stderr.print("[w] {s}\n", .{out_string});
+    var out_string = std.fmt.allocPrint(allocator, message, args);
+    stderr.print("[w] {s}\n", .{out_string}) catch {};
 }
 
-pub fn err(comptime message: []const u8, args: anytype) anyerror!void {
+pub fn err(comptime message: []const u8, args: anytype) void {
     var stderr = std.io.getStdErr().writer();
-    var out_string = try std.fmt.allocPrint(allocator, message, args);
-    try stderr.print("[!] {s}\n", .{out_string});
+    var out_string = std.fmt.allocPrint(allocator, message, args);
+    stderr.print("[!] {s}\n", .{out_string}) catch {};
 }
 
-pub fn crit(comptime message: []const u8, args: anytype) anyerror!void {
+pub fn crit(comptime message: []const u8, args: anytype) void {
     var stderr = std.io.getStdErr().writer();
-    var out_string = try std.fmt.allocPrint(allocator, message, args);
-    try stderr.print("[!!] {s}\n", .{out_string});
+    var out_string = std.fmt.allocPrint(allocator, message, args);
+    stderr.print("[!!] {s}\n", .{out_string}) catch {};
 }

--- a/src/maintenance.zig
+++ b/src/maintenance.zig
@@ -8,19 +8,19 @@ const MetaStruct = metadata.MetaStruct;
 
 pub fn do_maint(args: [][]u8, install_dir: []const u8) !void {
     if (args.len < 1) {
-        try logger.warn("No sub-command provided!", .{});
+        logger.warn("No sub-command provided!", .{});
     } else {
         if (std.mem.eql(u8, args[0], "uninstall")) {
             try do_uninstall(install_dir);
         }
     }
-    try logger.info("Quitting.", .{});
+    logger.info("Quitting.", .{});
 }
 
 fn confirm() !bool {
     var stdin = std.io.getStdIn().reader();
 
-    try logger.query("Please confirm this action [y/n]: ", .{});
+    logger.query("Please confirm this action [y/n]: ", .{});
 
     var buf: [8]u8 = undefined;
     if (try stdin.readUntilDelimiterOrEof(buf[0..], '\n')) |user_input| {
@@ -34,15 +34,15 @@ fn confirm() !bool {
 }
 
 fn do_uninstall(install_dir: []const u8) !void {
-    try logger.warn("This will uninstall the application runtime for this Burrito binary!", .{});
+    logger.warn("This will uninstall the application runtime for this Burrito binary!", .{});
     if ((try confirm()) == false) {
-        try logger.warn("Uninstall was aborted!", .{});
+        logger.warn("Uninstall was aborted!", .{});
         return;
     }
 
-    try logger.info("Deleting directory: {s}", .{install_dir});
+    logger.info("Deleting directory: {s}", .{install_dir});
     try std.fs.deleteTreeAbsolute(install_dir);
-    try logger.info("Uninstall complete!", .{});
+    logger.info("Uninstall complete!", .{});
 }
 
 pub fn do_clean_old_versions(install_prefix_path: []const u8, current_install_path: []const u8) !void {
@@ -74,7 +74,7 @@ pub fn do_clean_old_versions(install_prefix_path: []const u8, current_install_pa
             // Compare the version, if it's older, delete the directory
             if (std.SemanticVersion.order(current_install.?.version, other_install.?.version) == .gt) {
                 try prefix_dir.deleteTree(other_install.?.install_dir_path);
-                try logger.info("Uninstalled older version (v{s})", .{other_install.?.metadata.app_version});
+                logger.info("Uninstalled older version (v{s})", .{other_install.?.metadata.app_version});
             }
         }
     }

--- a/src/wrapper.zig
+++ b/src/wrapper.zig
@@ -84,8 +84,8 @@ pub fn main() anyerror!void {
 
     // Check for maintenance commands
     if (args_trimmed.len > 0 and std.mem.eql(u8, args_trimmed[0], "maintenance")) {
-        try logger.info("Entering burrito maintenance mode...", .{});
-        try logger.info("Build metadata: {s}", .{RELEASE_METADATA_JSON});
+        logger.info("Entering burrito maintenance mode...", .{});
+        logger.info("Build metadata: {s}", .{RELEASE_METADATA_JSON});
         try maint.do_maint(args_trimmed[1..], install_dir);
         return;
     }
@@ -150,15 +150,15 @@ fn do_payload_install(install_dir: []const u8, metadata_path: []const u8) !void 
 
 fn get_base_install_dir() ![]const u8 {
     const app_dir = fs.getAppDataDir(allocator, install_suffix) catch {
-        try install_dir_error();
+        install_dir_error();
         return "";
     };
 
     // If we have a override for the install path, use that, otherwise, continue to return
     // the standard install path
     if (std.process.getEnvVarOwned(allocator, "APPLICATION_INSTALL_DIR")) |new_path| {
-        try logger.info("Install path is being overriden using `APPLICATION_INSTALL_DIR`", .{});
-        try logger.info("New install path is: {s}", .{new_path});
+        logger.info("Install path is being overriden using `APPLICATION_INSTALL_DIR`", .{});
+        logger.info("New install path is: {s}", .{new_path});
         return try fs.path.join(allocator, &[_][]const u8{ new_path, install_suffix });
     } else |err| switch (err) {
         error.InvalidUtf8 => {},
@@ -177,25 +177,22 @@ fn get_install_dir(meta: *const MetaStruct) ![]u8 {
     const dir_name = try std.fmt.allocPrint(allocator, "{s}_erts-{s}_{s}", .{ build_options.RELEASE_NAME, meta.erts_version, meta.app_version });
 
     // Ensure that base directory is created
-    std.os.mkdir(base_install_path, 0o755) catch {
-        try install_dir_error();
-        return "";
-    };
+    std.os.mkdir(base_install_path, 0o755) catch {};
 
     // Construct the full app install path
     const name = fs.path.join(allocator, &[_][]const u8{ base_install_path, dir_name }) catch {
-        try install_dir_error();
+        install_dir_error();
         return "";
     };
 
     return name;
 }
 
-fn install_dir_error() !void {
-    try logger.err("We could not use the default directory we would normally use to run this application.", .{});
-    try logger.err("This may be due to a permissions error, or some system specific configurations.", .{});
-    try logger.err("Please override the default burrito install directory using the `APPLICATION_INSTALL_DIR` environment variable.", .{});
-    try logger.err("On Linux or MacOS you can run the command: `export APPLICATION_INSTALL_DIR=/some/other/path`", .{});
-    try logger.err("On Windows you can use: `SET APPLICATION_INSTALL_DIR=D:\\some\\other\\path`", .{});
+fn install_dir_error() noreturn {
+    logger.err("We could not install this application to the default directory.", .{});
+    logger.err("This may be due to a permission error.", .{});
+    logger.err("Please override the default burrito install directory using the `APPLICATION_INSTALL_DIR` environment variable.", .{});
+    logger.err("On Linux or MacOS you can run the command: `export APPLICATION_INSTALL_DIR=/some/other/path`", .{});
+    logger.err("On Windows you can use: `SET APPLICATION_INSTALL_DIR=D:\\some\\other\\path`", .{});
     std.process.exit(1);
 }

--- a/src/wrapper.zig
+++ b/src/wrapper.zig
@@ -177,7 +177,12 @@ fn get_install_dir(meta: *const MetaStruct) ![]u8 {
     const dir_name = try std.fmt.allocPrint(allocator, "{s}_erts-{s}_{s}", .{ build_options.RELEASE_NAME, meta.erts_version, meta.app_version });
 
     // Ensure that base directory is created
-    std.os.mkdir(base_install_path, 0o755) catch {};
+    std.os.mkdir(base_install_path, 0o755) catch |err| {
+        if (err != error.PathAlreadyExists) {
+            install_dir_error();
+            return "";
+        }
+    };
 
     // Construct the full app install path
     const name = fs.path.join(allocator, &[_][]const u8{ base_install_path, dir_name }) catch {


### PR DESCRIPTION
If a burrito application is run with the environment variable `BURRITO_INSTALL_DIR` set to a path, the burrito wrapper will extract the application to that directory instead.

This is useful for environments that have much more restrictive permissions.