### PR TITLE
Start req app in wrap/1

### DIFF
--- a/lib/burrito.ex
+++ b/lib/burrito.ex
@@ -31,8 +31,7 @@ defmodule Burrito do
 
     current_system = get_current_os()
 
-    :telemetry_sup.start_link()
-    Finch.start_link(name: Req.Finch)
+    {:ok, _} = Application.ensure_all_started(:req)
 
     Enum.each(targets, fn target ->
       if Enum.member?(@supported_targets, target) do


### PR DESCRIPTION
I believe the code is fine as is, however by properly starting the app (and importantly all its dependent apps) we ensure that any future update to the supervision tree doesn't break Burrito. (Not that I plan any!)
