### PR TITLE
Simplify version sorting

### DIFF
--- a/lib/versions/release_file.ex
+++ b/lib/versions/release_file.ex
@@ -111,7 +111,7 @@ defmodule Burrito.Versions.ReleaseFile do
         this_version = Map.get(release, "version", "0.0.0") |> Version.parse!()
         Version.compare(curr_version, this_version) == :lt
       end)
-      |> Enum.sort_by(fn r -> r["version"] |> Version.parse!() end, {:desc, Version})
+      |> Enum.sort_by(& &1["version"], {:desc, Version})
       |> List.first()
 
     newer_release


### PR DESCRIPTION
No need to parse the version given Version.compare/2 already does that
under the hood!

    iex> ~w(2.0.0 11.0.0 2.0.1) |> Enum.sort_by(& &1, {:desc, Version})
    ["11.0.0", "2.0.1", "2.0.0"]
