### PR TITLE
Fix fetching the wrong arch for MacOS releases

### DIFF
--- a/lib/util/default_erts_resolver.ex
+++ b/lib/util/default_erts_resolver.ex
@@ -16,7 +16,7 @@ defmodule Burrito.Util.DefaultERTSResolver do
 
   def do_resolve(%Target{erts_source: {:precompiled, version: otp_version}} = target)
       when is_binary(otp_version) do
-    case ERTSUrlFetcher.fetch_version(target.os, target.qualifiers[:libc], otp_version) do
+    case ERTSUrlFetcher.fetch_version(target.os, target.qualifiers[:libc], target.cpu, otp_version) do
       %URI{} = location ->
         %Target{target | erts_source: {:url, url: location}} |> do_resolve()
 

--- a/lib/util/erts_url_fetcher.ex
+++ b/lib/util/erts_url_fetcher.ex
@@ -11,9 +11,9 @@ defmodule Burrito.Util.ERTSUrlFetcher do
     %{windows: windows_releases, posix: posix_release}
   end
 
-  @spec fetch_version(atom(), atom(), String.t()) :: URI.t() | :error
-  def fetch_version(os, libc, otp_version)
-      when is_binary(otp_version) and is_atom(os) and is_atom(libc) do
+  @spec fetch_version(atom(), atom(), atom(), String.t()) :: URI.t() | :error
+  def fetch_version(os, libc, cpu, otp_version)
+      when is_binary(otp_version) and is_atom(os) and is_atom(cpu) and is_atom(libc) do
     all_versions = fetch_all_versions()
 
     res =
@@ -28,7 +28,11 @@ defmodule Burrito.Util.ERTSUrlFetcher do
         "win64"
       else
         if os == :darwin do
-          "darwin"
+          case cpu do
+            :x86_64 -> "darwin-x86_64"
+            :aarch64 -> "darwin-arm64"
+            :arm64 -> "darwin-arm64"
+          end
         else
           case libc do
             :musl -> "musl_libc"


### PR DESCRIPTION
We were fetching arm64 builds for all MacOS cross-builds, this passes in the CPU type and correctly filters out the right ERTS download URL.