### PR TITLE
Fixes NIF Sniffer argument match for the new ERTS fetcher

### DIFF
--- a/lib/steps/patch/recompile_nifs.ex
+++ b/lib/steps/patch/recompile_nifs.ex
@@ -49,7 +49,7 @@ defmodule Burrito.Steps.Patch.RecompileNIFs do
   defp maybe_recompile_nif(
          {dep, path, true},
          release_working_path,
-         {:unpacked, erts_path},
+         erts_path,
          cross_target
        ) do
     dep = Atom.to_string(dep)
@@ -68,8 +68,8 @@ defmodule Burrito.Steps.Patch.RecompileNIFs do
         env: [
           {"RANLIB", "zig ranlib"},
           {"AR", "zig ar"},
-          {"CC", "zig cc -target #{cross_target} -v -shared"},
-          {"CXX", "zig c++ -target #{cross_target} -v -shared"},
+          {"CC", "zig cc -target #{cross_target} -v -shared -Wl,-undefined=dynamic_lookup"},
+          {"CXX", "zig c++ -target #{cross_target} -v -shared -Wl,-undefined=dynamic_lookup"},
           {"CXXFLAGS", "-I#{erts_include}"},
           {"CFLAGS", "-I#{erts_include}"}
         ],


### PR DESCRIPTION
This lagged behind in the refactor because we didn't have any examples that actually used the NIF sniffer, this will be fixed int he upcoming examples I'm working on!

It also fixes dynamic flags for recompilation in Zig 0.10.0+