### PR TITLE
Pin to zig 0.9.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-zig 0.9.0
+zig 0.9.1
 erlang 24.1.1
 elixir 1.12.3-otp-24


### PR DESCRIPTION
Doesn't seem to have broken any of our calls, and contains some bugfixes. See https://ziglang.org/download/0.9.1/release-notes.html.