### PR TITLE
Fix up NIF xcomp and change install suffix

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -72,9 +72,11 @@ pub fn build_wrapper() !void {
     wrapper_exe.setBuildMode(mode.*);
 
     if (target.isWindows()) {
-        wrapper_exe.linkSystemLibrary("c");
         wrapper_exe.addIncludeDir("src/");
     }
+
+    // Link standard C libary to the wrapper
+    wrapper_exe.linkSystemLibrary("c");
 
     if (plugin_path) |plugin| {
         log.info("Plugin found! {s} 🔌", .{plugin});

--- a/lib/steps/patch/recompile_nifs.ex
+++ b/lib/steps/patch/recompile_nifs.ex
@@ -83,7 +83,10 @@ defmodule Burrito.Steps.Patch.RecompileNIFs do
       {_, 0} ->
         Log.info(:step, "Successfully re-built #{dep} for #{cross_target}!")
 
-        src_priv_files = Path.join(path, ["priv/*"]) |> Path.expand() |> Path.wildcard()
+        src_priv_files =
+          Path.join(path, ["_build/", Mix.env() |> to_string(), "/lib/", dep, "/priv/*"])
+          |> Path.expand()
+          |> Path.wildcard()
 
         output_priv_dir =
           Path.join(release_working_path, ["lib/#{dep}*/priv"])

--- a/src/wrapper.zig
+++ b/src/wrapper.zig
@@ -22,7 +22,7 @@ const shutil = @import("shutil.zig");
 const win_asni = @cImport(@cInclude("win_ansi_fix.h"));
 
 // Install dir suffix
-const install_suffix = ".tinfoil";
+const install_suffix = ".burrito";
 
 const plugin = @import("burrito_plugin");
 


### PR DESCRIPTION
* Fixes up using the wrong path when recompiling a NIF in `elixir_make`
* Changes the old `.tinfoil` install directory suffix to `.burrito`
* XZ always needs the system C stblib to be linked