### PR TITLE
WIP: Auto-fetch Zig for users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ erl_crash.dump
 *.beam
 /config/*.secret.exs
 .elixir_ls/
+/zig_bin*

--- a/bin/fetch_zig.sh
+++ b/bin/fetch_zig.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-ZIG_URL=$(curl -s https://ziglang.org/download/index.json | jq --raw-output ".master.\"x86_64-linux\".\"tarball\"")
+ZIG_URL=$(curl -s https://ziglang.org/download/index.json | jq --raw-output ".\"0.10.0\".\"x86_64-linux\".\"tarball\"")
 wget --show-progress -O zig.tar.xz $ZIG_URL

--- a/lib/burrito.ex
+++ b/lib/burrito.ex
@@ -1,10 +1,15 @@
 defmodule Burrito do
   alias Burrito.Builder
   alias Burrito.Builder.Log
+  alias Burrito.Util.ZigFetch
 
   @spec wrap(Mix.Release.t()) :: Mix.Release.t()
   def wrap(%Mix.Release{} = release) do
     pre_check()
+
+    {:ok, _} = Application.ensure_all_started(:req)
+
+    ZigFetch.auto_fetch()
     Builder.build(release)
   end
 
@@ -13,10 +18,10 @@ defmodule Burrito do
   end
 
   defp pre_check() do
-    if Enum.any?(~w(zig xz), &(System.find_executable(&1) == nil)) do
+    if Enum.any?(~w(xz), &(System.find_executable(&1) == nil)) do
       Log.error(
         :build,
-        "You MUST have `zig` and `xz` installed to use Burrito, we couldn't find all of them in your PATH!"
+        "You MUST have `xz` installed to use Burrito! We couldn't find it in your PATH!"
       )
 
       exit(1)

--- a/lib/util/erts_url_fetcher.ex
+++ b/lib/util/erts_url_fetcher.ex
@@ -6,8 +6,6 @@ defmodule Burrito.Util.ERTSUrlFetcher do
 
   @spec fetch_all_versions() :: %{windows: list(), posix: list()}
   def fetch_all_versions() do
-    {:ok, _} = Application.ensure_all_started(:req)
-
     with {:ok, windows_releases} <- get_gh_pages(@versions_url_windows),
          {:ok, posix_releases} <- get_gh_pages(@versions_url_darwin_linux) do
       %{windows: windows_releases, posix: posix_releases}

--- a/lib/util/zig_fetch.ex
+++ b/lib/util/zig_fetch.ex
@@ -1,0 +1,105 @@
+defmodule Burrito.Util.ZigFetch do
+  alias Burrito.Util
+  require Logger
+
+  # Index of all Zig releases
+  @zig_srouce "https://ziglang.org/download/index.json"
+
+  # The version of Zig burrito is currently using
+  @zig_version "0.10.0"
+
+  @spec auto_fetch :: :error | :ok
+  def auto_fetch do
+    cpu = Util.get_current_cpu()
+    os = Util.get_current_os()
+    fetch_zig(os, cpu)
+  end
+
+  @spec fetch_zig(any, any) :: :error | :ok
+  def fetch_zig(os, cpu) do
+    extracted_stamp = Path.join([compute_install_location(), "/EXTRACTED.stamp"])
+
+    if File.exists?(extracted_stamp) do
+      Logger.info(
+        "Zig #{@zig_version} is already installed at #{compute_install_location()} for #{os} #{cpu}"
+      )
+
+      :ok
+    else
+      Logger.info("Fetching Zig for your host platform...")
+
+      release_index = fetch_release_index()
+
+      case fetch_archive(os, cpu, release_index) do
+        {:ok, data} ->
+          do_unpack(data, compute_install_location())
+
+        _ ->
+          :error
+      end
+    end
+  end
+
+  @spec compute_install_location :: binary
+  def compute_install_location() do
+    self_path =
+      __ENV__.file
+      |> Path.dirname()
+      |> Path.split()
+      |> List.delete_at(-1)
+      |> List.delete_at(-1)
+      |> List.insert_at(-1, "zig_bin_#{@zig_version}")
+      |> Path.join()
+
+    File.mkdir_p!(self_path)
+
+    self_path
+  end
+
+  defp fetch_release_index() do
+    case Req.get!(@zig_srouce) do
+      %Req.Response{status: 200, body: json_body} ->
+        json_body
+
+      _ ->
+        Logger.error(
+          "Error fetching Zig release index. Ensure you are connected to the internet."
+        )
+
+        :error
+    end
+  end
+
+  defp fetch_archive(_os, _cpu, :error) do
+    :error
+  end
+
+  defp fetch_archive(os, cpu, index) do
+    releases = index[@zig_version] || []
+    release_name = "#{cpu}-#{translate_os(os)}"
+
+    {_, found_release} =
+      Enum.find(releases, %{}, fn {name, _metadata} -> name == release_name end)
+
+    if Map.has_key?(found_release, "tarball") do
+      %Req.Response{status: 200, body: data} = Req.get!(found_release["tarball"])
+      {:ok, data}
+    else
+      :error
+    end
+  end
+
+  defp do_unpack(tarball_data, install_location) do
+    out_archive = Path.join([install_location, "/zig.tar.xz"])
+    File.write!(out_archive, tarball_data)
+
+    {_, 0} =
+      System.cmd("tar", ["-xf", "zig.tar.xz", "--strip-components", "1"], cd: install_location)
+
+    stamp = Path.join([install_location, "/EXTRACTED.stamp"])
+    File.touch!(stamp)
+  end
+
+  defp translate_os(:darwin), do: :macos
+  defp translate_os(name), do: name
+end


### PR DESCRIPTION
Zig versions can get confusing due to how quickly the language moves and changes.

Since it's so portable, this PR introduces a module that can determine the current host platform, and auto-downloads a Zig build of the version we lock to, and extracts it into the Burrito `deps` directory.

All `zig` operations in the builder steps have been replaced with a call to computer the path to the caches `zig` binary instead of using the system `zig`

TODO: We probably want to allow people to override this, perhaps a `BURRITO_USE_SYSTEM_ZIG` environment variable.