### PR TITLE
Don't attempt to "replace" bins when building (aka the EMPEX Bug)

### DIFF
--- a/lib/steps/build/copy_release.ex
+++ b/lib/steps/build/copy_release.ex
@@ -35,6 +35,12 @@ defmodule Burrito.Steps.Build.CopyRelease do
 
     output_bin_path = Path.join(bin_out_path, [bin_name])
 
+    # Delete the existing bin, to prevent a MacOS bug
+    # where exiting bins modified in place cause SIP to be upset
+    if File.exists?(output_bin_path) do
+      File.rm!(output_bin_path)
+    end
+
     File.copy!(bin_path, output_bin_path)
     File.rm!(bin_path)
 

--- a/src/wrapper.zig
+++ b/src/wrapper.zig
@@ -104,6 +104,14 @@ pub fn main() anyerror!void {
 
     // If we need an install, install the payload onto the target machine
     if (needs_install or wants_clean_install) {
+        // If running a clean install (probably a debug build)
+        // delete existing install directory if it's present to prevent a MacOS SIP issue
+        // when "replacing" a mach-o in place
+        if (wants_clean_install and !needs_install) {
+            try fs.deleteTreeAbsolute(install_dir);
+            try std.fs.cwd().makePath(install_dir);
+        }
+
         try do_payload_install(install_dir, metadata_path);
     } else {
         log.debug("Skipping archive unpacking, this machine already has the app installed!", .{});


### PR DESCRIPTION
During my talk I very quickly learned that MacOS dislikes it if you copy a binary with the same name over an existing binary you've already run. (This extends to libraries loaded dynamically as well)

The trick around this is to simply delete the old bin before copying the new one. So these changes do the following:

- When building binaries, delete ones we are overwriting before we copy the new one into `burrito_out`
- When forcing a clean install, wipe out the old one first.