### PR TITLE
Forward the exit code on Windows

### DIFF
--- a/src/scripts/win_start.bat.eex
+++ b/src/scripts/win_start.bat.eex
@@ -42,7 +42,7 @@ if "!RELEASE_DISTRIBUTION!" == "none" (
   set RELEASE_DISTRIBUTION_FLAG=--!RELEASE_DISTRIBUTION! "!RELEASE_NODE!"
 )
 
-"!REL_VSN_DIR!\!REL_EXEC!.bat" !REL_EXTRA! ^
+call "!REL_VSN_DIR!\!REL_EXEC!.bat" !REL_EXTRA! ^
   --cookie "!RELEASE_COOKIE!" ^
   !RELEASE_DISTRIBUTION_FLAG! ^
   --erl "-mode !RELEASE_MODE!" ^
@@ -50,3 +50,5 @@ if "!RELEASE_DISTRIBUTION!" == "none" (
   --boot "!REL_VSN_DIR!\!RELEASE_BOOT_SCRIPT!" ^
   --boot-var RELEASE_LIB "!RELEASE_ROOT!\lib" ^
   --vm-args "!RELEASE_VM_ARGS!" -- %*
+
+exit /b %ERRORLEVEL%

--- a/src/wrapper.zig
+++ b/src/wrapper.zig
@@ -179,7 +179,13 @@ pub fn main() anyerror!void {
 
         log.debug("CLI List: {s}", .{final_args});
 
-        _ = try win_child_proc.spawnAndWait();
+        const win_term = try win_child_proc.spawnAndWait();
+        switch (win_term) {
+            .Exited => |code| {
+                std.process.exit(code);
+            },
+            else => std.process.exit(1),
+        }
     } else {
         const cli = &[_][]const u8{ base_bin_path, "start", exe_name, args_string };
         log.debug("CLI List: {s}", .{cli});


### PR DESCRIPTION
Previously the exit code was always 0. This exits from the batch script with the nested batch script exit code,
which is now caught in the Zig wrapper and forwarded.