### PR TITLE
Allow typed struct 0.3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Burrito.MixProject do
   defp deps do
     [
       {:req, "~> 0.2.0"},
-      {:typed_struct, "~> 0.2.1", runtime: false},
+      {:typed_struct, "~> 0.2.0 or ~> 0.3.0", runtime: false},
       {:jason, "~> 1.2"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -8,5 +8,5 @@
   "nimble_pool": {:hex, :nimble_pool, "0.2.4", "1db8e9f8a53d967d595e0b32a17030cdb6c0dc4a451b8ac787bf601d3f7704c3", [:mix], [], "hexpm", "367e8071e137b787764e6a9992ccb57b276dc2282535f767a07d881951ebeac6"},
   "req": {:hex, :req, "0.2.0", "b4afce31dfc9648779e78538347c669abc932f5478692457be237f7874d8aaf1", [:mix], [{:finch, "~> 0.8.1", [hex: :finch, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}, {:mime, "~> 1.6 or ~> 2.0", [hex: :mime, repo: "hexpm", optional: false]}, {:nimble_csv, "~> 1.0", [hex: :nimble_csv, repo: "hexpm", optional: true]}], "hexpm", "5e7cafb25a2d6c246d88a66129b80bdd3dd7603d18693cb353763172004b2d1e"},
   "telemetry": {:hex, :telemetry, "1.0.0", "0f453a102cdf13d506b7c0ab158324c337c41f1cc7548f0bc0e130bbf0ae9452", [:rebar3], [], "hexpm", "73bc09fa59b4a0284efb4624335583c528e07ec9ae76aca96ea0673850aec57a"},
-  "typed_struct": {:hex, :typed_struct, "0.2.1", "e1993414c371f09ff25231393b6430bd89d780e2a499ae3b2d2b00852f593d97", [:mix], [], "hexpm", "8f5218c35ec38262f627b2c522542f1eae41f625f92649c0af701a6fab2e11b3"},
+  "typed_struct": {:hex, :typed_struct, "0.3.0", "939789e3c1dca39d7170c87f729127469d1315dcf99fee8e152bb774b17e7ff7", [:mix], [], "hexpm", "c50bd5c3a61fe4e198a8504f939be3d3c85903b382bde4865579bc23111d1b6d"},
 }


### PR DESCRIPTION
This also relaxes the typed_struct requirements to the 0.2 series as we don't depend on 0.2.1 behavior.

https://github.com/ejpcmac/typed_struct/blob/main/CHANGELOG.md