### PR TITLE
Treat the target ERTS as the source manifest for DLL and SO files

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 zig 0.9.1
-erlang 24.1.1
-elixir 1.12.3-otp-24
+erlang 25.0.3
+elixir 1.13.4-otp-25

--- a/lib/builder/log.ex
+++ b/lib/builder/log.ex
@@ -3,6 +3,10 @@ defmodule Burrito.Builder.Log do
     IO.puts(get_prefix(type) <> message)
   end
 
+  def success(type, message) do
+    IO.puts(:stderr, IO.ANSI.green() <> get_prefix(type) <> message <> IO.ANSI.reset())
+  end
+
   def warning(type, message) do
     IO.puts(:stderr, IO.ANSI.yellow() <> get_prefix(type) <> message <> IO.ANSI.reset())
   end


### PR DESCRIPTION
This addresses a bug that cropped up in ERTS 13.0+

See issue: https://github.com/burrito-elixir/burrito/issues/66

Essentially, the MacOS/Host ERTS did not have a `lib/public_key-1.13/priv/lib/public_key.so` file present. This means when we evaluate the NIFs to replace in the ERTS install, we don't consider copying the `public_key.dll` file from the new ERTS to the destination ERTS.

This is because we treated the "host" or the "original" ERTS as the authority to create the manifest of NIF libraries to copy over. The changes in this PR reverse the operation, we now look for all the NIF libraries in the _NEW ERTS_ and use _THAT_ as a manifest of files to copy over or overwrite in the destination ERTS.

This means that even if `public_key.so` wasn't present in the original ERTS, we will still copy over the `public_key.dll` from the new ERTS.

We still log when we "replace" a library, and log every library we copy over into the destination ERTS.