### PR TITLE
Support automatic file decompression by Req

### DIFF
--- a/lib/util/default_erts_resolver.ex
+++ b/lib/util/default_erts_resolver.ex
@@ -110,6 +110,7 @@ defmodule Burrito.Util.DefaultERTSResolver do
   end
 
   defp do_download(url, cache_key) do
+    {:ok, _} = Application.ensure_all_started(:req)
     Log.info(:step, "Downloading file: #{url}")
     data = Req.get!(url).body
     FileCache.put_if_not_exist(cache_key, data)


### PR DESCRIPTION
Fixes a bug when using a custom ERTS through URL for a .tar.gz file that Req would automatically decompress.