### PR TITLE
fix: use System.halt(1) instead of exit(1)

### DIFF
--- a/lib/builder/builder.ex
+++ b/lib/builder/builder.ex
@@ -152,7 +152,7 @@ defmodule Burrito.Builder do
           "Halt requested from phase: #{inspect(phase_name)} in step #{inspect(mod)}"
         )
 
-        exit(1)
+        System.halt(1)
       end
 
       new_context

--- a/lib/burrito.ex
+++ b/lib/burrito.ex
@@ -19,7 +19,7 @@ defmodule Burrito do
         "You MUST have `zig` and `xz` installed to use Burrito, we couldn't find all of them in your PATH!"
       )
 
-      exit(1)
+      System.halt(1)
     end
 
     if Enum.any?(~w(7z), &(System.find_executable(&1) == nil)) do

--- a/lib/steps/patch/recompile_nifs.ex
+++ b/lib/steps/patch/recompile_nifs.ex
@@ -105,10 +105,9 @@ defmodule Burrito.Steps.Patch.RecompileNIFs do
           end
         end)
 
-      {output, _} ->
+      {_output, _} ->
         Log.error(:step, "Failed to rebuild #{dep} for #{cross_target}!")
-        Log.error(:step, output)
-        exit(1)
+        System.halt(1)
     end
   end
 


### PR DESCRIPTION
- fix log error
```shell
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not a bitstring

    :erlang.bit_size(%IO.Stream{device: :standard_io, raw: false, line_or_bytes: :line})
    (burrito 0.8.0) Burrito.Builder.Log.error/2
    (burrito 0.8.0) lib/steps/patch/recompile_nifs.ex:110: Burrito.Steps.Patch.RecompileNIFs.maybe_recompile_nif/4
    (elixir 1.14.1) lib/enum.ex:975: Enum."-each/2-lists^foreach/1-0-"/2
    (burrito 0.8.0) lib/steps/patch/recompile_nifs.ex:17: Burrito.Steps.Patch.RecompileNIFs.execute/1
    (burrito 0.8.0) lib/builder/builder.ex:146: anonymous fn/3 in Burrito.Builder.run_phase/2
    (elixir 1.14.1) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
    (elixir 1.14.1) lib/enum.ex:975: Enum."-each/2-lists^foreach/1-0-"/2
```

- `exit(1)` show useless output like bottom, use `System.halt(1)` instead of `exit(1)` maybe better
```shell
** (exit) 1
    (burrito 0.8.0) lib/steps/patch/recompile_nifs.ex:110: Burrito.Steps.Patch.RecompileNIFs.maybe_recompile_nif/4
    (elixir 1.14.1) lib/enum.ex:975: Enum."-each/2-lists^foreach/1-0-"/2
    (burrito 0.8.0) lib/steps/patch/recompile_nifs.ex:17: Burrito.Steps.Patch.RecompileNIFs.execute/1
    (burrito 0.8.0) lib/builder/builder.ex:146: anonymous fn/3 in Burrito.Builder.run_phase/2
    (elixir 1.14.1) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
    (elixir 1.14.1) lib/enum.ex:975: Enum."-each/2-lists^foreach/1-0-"/2
    (burrito 0.8.0) lib/builder/builder.ex:95: Burrito.Builder.build/1
    (mix 1.14.1) lib/mix/tasks/release.ex:1068: Mix.Tasks.Release.run_steps/1
```