### PR TITLE
fix: use `/bin/sh` rather than `/bin/bash`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -36,7 +36,7 @@ pub fn run_archiver() !void {
     const release_path = std.os.getenv("__BURRITO_RELEASE_PATH");
     try foilz.pack_directory(release_path.?, "./payload.foilz");
 
-    const compress_cmd = builder.addSystemCommand(&[_][]const u8{ "/bin/bash", "-c", "xz -9ez --check=crc32 --stdout --keep payload.foilz > src/payload.foilz.xz" });
+    const compress_cmd = builder.addSystemCommand(&[_][]const u8{ "/bin/sh", "-c", "xz -9ez --check=crc32 --stdout --keep payload.foilz > src/payload.foilz.xz" });
     try compress_cmd.step.make();
 }
 


### PR DESCRIPTION
`/bin/bash` is not guaranteed to be present on the system (unlike `/bin/sh`)

Moreover, this will produce confusing results for e.g. Mac users, who install `bash` via brew

Since Bash is not necessary for the use case, just use portable `/bin/sh`