### PR TITLE
[Carcinization] Swap to invoking Rust compiler and executable

### DIFF
--- a/lib/builder/target.ex
+++ b/lib/builder/target.ex
@@ -97,22 +97,22 @@ defmodule Burrito.Builder.Target do
   def make_triplet(%Target{} = target) do
     os =
       case target.os do
-        :darwin -> "macos"
-        :windows -> "windows"
-        :linux -> "linux"
+        :darwin -> "apple-darwin"
+        :windows -> "pc-windows"
+        :linux -> "unknown-linux"
       end
 
     triplet = "#{target.cpu}-#{os}"
 
     if target.qualifiers[:libc] do
-      libc = translate_libc_to_zig(target.qualifiers[:libc])
+      libc = translate_libc_to_wrapper(target.qualifiers[:libc])
       "#{triplet}-#{libc}"
     else
       triplet
     end
   end
 
-  defp translate_libc_to_zig(:gnu), do: "gnu"
-  defp translate_libc_to_zig(:musl), do: "musl"
-  defp translate_libc_to_zig(abi), do: Atom.to_string(abi)
+  defp translate_libc_to_wrapper(:gnu), do: "gnu"
+  defp translate_libc_to_wrapper(:musl), do: "musl"
+  defp translate_libc_to_wrapper(abi), do: Atom.to_string(abi)
 end

--- a/lib/burrito.ex
+++ b/lib/burrito.ex
@@ -13,10 +13,10 @@ defmodule Burrito do
   end
 
   defp pre_check() do
-    if Enum.any?(~w(zig xz), &(System.find_executable(&1) == nil)) do
+    if Enum.any?(~w(rustc xz), &(System.find_executable(&1) == nil)) do
       Log.error(
         :build,
-        "You MUST have `zig` and `xz` installed to use Burrito, we couldn't find all of them in your PATH!"
+        "You MUST have `rust` and `xz` installed to use Burrito, we couldn't find all of them in your PATH!"
       )
 
       exit(1)

--- a/lib/steps/build/pack_and_build.ex
+++ b/lib/steps/build/pack_and_build.ex
@@ -14,9 +14,9 @@ defmodule Burrito.Steps.Build.PackAndBuild do
 
     plugin_path = maybe_get_plugin_path(options[:plugin])
 
-    zig_build_args = ["-Dtarget=#{build_triplet}"]
+    build_args = ["--target=#{build_triplet}"]
 
-    create_metadata_file(context.self_dir, zig_build_args, context.mix_release)
+    create_metadata_file(context.self_dir, build_args, context.mix_release)
 
     # TODO: Why do we need to do this???
     # This is to bypass a VERY strange bug inside Linux containers...
@@ -26,8 +26,8 @@ defmodule Burrito.Steps.Build.PackAndBuild do
     Path.join(context.work_dir, ["/lib", "/.burrito"]) |> File.touch!()
 
     build_result =
-      System.cmd("zig", ["build"] ++ zig_build_args,
-        cd: context.self_dir,
+      System.cmd("cargo", ["build"] ++ build_args,
+        cd: Path.join(context.self_dir, "/wrapper"),
         env: [
           {"__BURRITO_IS_PROD", is_prod(context.target)},
           {"__BURRITO_RELEASE_PATH", context.work_dir},
@@ -64,11 +64,11 @@ defmodule Burrito.Steps.Build.PackAndBuild do
   defp create_metadata_file(self_path, args, release) do
     Log.info(:step, "Generating wrapper metadata file...")
 
-    {zig_version_string, 0} = System.cmd("zig", ["version"], cd: self_path)
+    {version_string, 0} = System.cmd("cargo", ["version"], cd: self_path, stderr_to_stdout: true)
 
     metadata_map = %{
       app_name: Atom.to_string(release.name),
-      zig_version: zig_version_string |> String.trim(),
+      zig_version: version_string |> String.trim(),
       zig_build_arguments: args,
       app_version: release.version,
       options: inspect(release.options),
@@ -91,13 +91,11 @@ defmodule Burrito.Steps.Build.PackAndBuild do
   defp clean_build(self_path) do
     Log.info(:step, "Cleaning up...")
 
-    cache = Path.join(self_path, "zig-cache")
-    out = Path.join(self_path, "zig-out")
+    out = Path.join(self_path, "wrapper/target")
     payload = Path.join(self_path, "payload.foilz")
     compressed_payload = Path.join(self_path, ["src/", "payload.foilz.xz"])
     metadata = Path.join(self_path, ["src/", "_metadata.json"])
 
-    File.rmdir(cache)
     File.rmdir(out)
     File.rm(payload)
     File.rm(compressed_payload)


### PR DESCRIPTION
Replace invocations of zig with cargo and have elixir point to the rust executable instead.