### PR TITLE
Improve Docs: Maintenance commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ Binaries built by Burrito include a built-in set of commands for performing main
 
 * `./my-binary maintenance uninstall` - Will prompt to uninstall the unpacked payload on the host machine.
 
+* `./my-binary maintenance directory`- Will print the path to the installation directory for the unpacked payload on the host machine.
+
+* `./my-binary maintenance meta` - Will print the metadata for binary.
+
 ## Advanced Build Configuration
 
 #### Build Steps and Phases


### PR DESCRIPTION
Hey,

i noticed there were some undocumented maintenance commands and i wanted to add them. Hope i did understand the zig code correctly.

Just one additional question, i also would like to improve the docs:

The README says:
> NOTE: In order to speed up iteration times during development, if the Mix environment is not set to prod, the binary will always extract its payload, even if that version of the application has already been unpacked on the target machine.

How can i configure my application so that a new version of the binary automatically overwrites the existing unpacked payload? I am using the same version number, so that is probably why i always have to use `binary maintenance uninstall` before.
Can we set a flag to automatically overwrite the existing payload?

Cheers and thank you for this great library
Kevin