### PR TITLE
fix: log uninstall message to stderr

### DIFF
--- a/src/logger.zig
+++ b/src/logger.zig
@@ -10,6 +10,12 @@ pub fn query(comptime message: []const u8, args: anytype) void {
     stdout.print("[?] {s}", .{out_string}) catch {};
 }
 
+pub fn log(comptime message: []const u8, args: anytype) void {
+    var stderr = std.io.getStdErr().writer();
+    var out_string = std.fmt.allocPrint(allocator, message, args) catch { return; };
+    stderr.print("[l] {s}\n", .{out_string}) catch {};
+}
+
 pub fn info(comptime message: []const u8, args: anytype) void {
     var stdout = std.io.getStdOut().writer();
     var out_string = std.fmt.allocPrint(allocator, message, args) catch { return; };

--- a/src/maintenance.zig
+++ b/src/maintenance.zig
@@ -95,7 +95,7 @@ pub fn do_clean_old_versions(install_prefix_path: []const u8, current_install_pa
             // Compare the version, if it's older, delete the directory
             if (std.SemanticVersion.order(current_install.?.version, other_install.?.version) == .gt) {
                 try std.fs.deleteTreeAbsolute(other_install.?.install_dir_path);
-                logger.info("Uninstalled older version (v{s})", .{other_install.?.metadata.app_version});
+                logger.log("Uninstalled older version (v{s})", .{other_install.?.metadata.app_version});
             }
         }
     }


### PR DESCRIPTION
Logs like these that are ancillary but not the primary output of the
tool can confuse tools when piping the output into stdin of another
application.

Logging to stderr helps solve this by presenting it to the user, but not
to other tools.

Note: I made another function rather than changing the behavior of an existing function, to help not break other usages of them.

Note: Still need to test this locally (unless you want to 😉).
