### PR TITLE
Update burrito to work with Zig 0.11.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-zig 0.10.0
+zig 0.11.0
 erlang 25.3
 elixir 1.14.4-otp-25

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ That being said, we're excited by our early use of the tooling, and are eager to
 
 You must have the following installed and in your PATH:
 
-* Zig (0.10.0) -- `zig`
+* Zig (0.11.0) -- `zig`
 * XZ -- `xz`
 * 7z -- `7z` (For Windows Targets)
 

--- a/bin/fetch_zig.sh
+++ b/bin/fetch_zig.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-ZIG_VERSION="0.10.0"
+ZIG_VERSION="0.11.0"
 
 ####
 

--- a/src/archiver.zig
+++ b/src/archiver.zig
@@ -62,7 +62,7 @@ pub fn pack_directory(path: []const u8, archive_path: []const u8) anyerror!void 
     try write_magic_number(&foilz_writer);
 
     while (try walker.next()) |entry| {
-        if (entry.kind == .File) {
+        if (entry.kind == .file) {
             // Replace some path string data for the tar index name
             // specifically replace: '../_build/prod/rel/' --> ''
             // This just makes it easier to write the files out later on the destination machine
@@ -210,7 +210,7 @@ pub fn unpack_files(data: []const u8, dest_path: []const u8, uncompressed_size: 
             }
             file.close();
         } else {
-            const file = try fs.createFileAbsolute(full_file_path, .{ .truncate = true, .mode = @intCast(os.mode_t, file_mode) });
+            const file = try fs.createFileAbsolute(full_file_path, .{ .truncate = true, .mode = @intCast(file_mode) });
             if (file_len > 0) {
                 try file.writeAll(file_data);
             }

--- a/src/maintenance.zig
+++ b/src/maintenance.zig
@@ -78,7 +78,7 @@ pub fn do_clean_old_versions(install_prefix_path: []const u8, current_install_pa
 
     var itr = prefix_dir.iterate();
     while (try itr.next()) |dir| {
-        if (dir.kind == .Directory) {
+        if (dir.kind == .directory) {
             const possible_app_path = try std.fs.path.join(allocator, &[_][]const u8{ install_prefix_path, dir.name });
             const other_install = try install.load_install_from_path(allocator, possible_app_path);
 

--- a/src/metadata.zig
+++ b/src/metadata.zig
@@ -10,12 +10,10 @@ pub const MetaStruct = struct {
 };
 
 pub fn parse(allocator: std.mem.Allocator, string_data: []const u8) ?MetaStruct {
-    const options = .{ .allocator = allocator };
-    var token_stream = std.json.TokenStream.init(string_data);
-    const metadata_parsed = std.json.parse(MetaStruct, &token_stream, options) catch |e| {
+    const metadata_parsed = std.json.parseFromSlice(MetaStruct, allocator, string_data, .{}) catch |e| {
         std.log.err("Error when parsing metadata: {!}", .{e});
         return null;
     };
 
-    return metadata_parsed;
+    return metadata_parsed.value;
 }

--- a/src/wrapper.zig
+++ b/src/wrapper.zig
@@ -55,7 +55,7 @@ pub fn main() anyerror!void {
         var windows_arg_list = std.ArrayList([]u8).init(allocator);
         var i: c_int = 0;
         while (i < arg_count) : (i += 1) {
-            var index = @intCast(usize, i);
+            var index = i;
             var length = std.mem.len(raw_args.?[index]);
             const argument = try std.unicode.utf16leToUtf8Alloc(allocator, raw_args.?[index][0..length]);
             try windows_arg_list.append(argument);


### PR DESCRIPTION
* This was required due to a bug compiling Zig 0.10.0 on macOS Sonoma
* Updates the `build.zig` file to be compatible with Zig 0.11.0
* Updates the wrapper source code to be compatible with Zig 0.11.0