### PR TITLE
fix: parse URI after identifying it as such

### DIFF
--- a/lib/builder/target.ex
+++ b/lib/builder/target.ex
@@ -57,7 +57,7 @@ defmodule Burrito.Builder.Target do
     if custom_location do
       cond do
         is_uri?(custom_location) ->
-          {:url, url: custom_location}
+          {:url, url: URI.new!(custom_location)}
 
         String.ends_with?(custom_location, ".tar.gz") or
             String.ends_with?(custom_location, ".exe") ->


### PR DESCRIPTION
this function was added in 1.13, let me know if that is not acceptable
