### PR TITLE
Universal LibC + Tons of updates

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -54,6 +54,7 @@ pub fn build_wrapper() !void {
     const release_name = try std.process.getEnvVarOwned(allocator, "__BURRITO_RELEASE_NAME");
     const plugin_path = std.process.getEnvVarOwned(allocator, "__BURRITO_PLUGIN_PATH") catch null;
     const is_prod = std.process.getEnvVarOwned(allocator, "__BURRITO_IS_PROD") catch "1";
+    const musl_runtime_path = std.process.getEnvVarOwned(allocator, "__BURRITO_MUSL_RUNTIME_PATH") catch "";
     var opt_level = std.builtin.Mode.Debug;
 
     if (std.mem.eql(u8, is_prod, "1")) {
@@ -80,6 +81,7 @@ pub fn build_wrapper() !void {
     exe_options.addOption(u64, "UNCOMPRESSED_SIZE", uncompressed_size);
 
     exe_options.addOption(bool, "IS_PROD", std.mem.eql(u8, is_prod, "1"));
+    exe_options.addOption([]const u8, "MUSL_RUNTIME_PATH", musl_runtime_path);
 
     if (target.isWindows()) {
         wrapper_exe.addIncludePath(.{ .path = "src/" });

--- a/examples/cli_example/lib/example_cli_app.ex
+++ b/examples/cli_example/lib/example_cli_app.ex
@@ -3,8 +3,31 @@ defmodule ExampleCliApp do
     args = Burrito.Util.Args.get_arguments()
 
     IO.puts("My arguments are: #{inspect(args)}")
-    IO.puts("'Random' number is #{1..999 |> Enum.random()} ... luck of the draw!!")
+
+    IO.write("Testing Crypto (Generating ed25519 key-pair)...")
+    test_crypto()
+    IO.write("OK\n")
+
+    IO.write("Testing Sqlite...")
+    test_sqlite()
+    IO.write("OK\n")
 
     System.halt(0)
+  end
+
+  defp test_crypto() do
+    {_pub, _priv} = :crypto.generate_key(:eddsa, :ed25519)
+  end
+
+  defp test_sqlite() do
+    {:ok, conn} = Exqlite.Sqlite3.open(":memory:")
+    :ok = Exqlite.Sqlite3.execute(conn, "create table test (id integer primary key, stuff text)")
+    {:ok, statement} = Exqlite.Sqlite3.prepare(conn, "insert into test (stuff) values (?1)")
+    :ok = Exqlite.Sqlite3.bind(conn, statement, ["Hello world"])
+    :done = Exqlite.Sqlite3.step(conn, statement)
+    {:ok, statement} = Exqlite.Sqlite3.prepare(conn, "select id, stuff from test")
+    {:row, [1, "Hello world"]} = Exqlite.Sqlite3.step(conn, statement)
+    :done = Exqlite.Sqlite3.step(conn, statement)
+    :ok = Exqlite.Sqlite3.release(conn, statement)
   end
 end

--- a/examples/cli_example/mix.exs
+++ b/examples/cli_example/mix.exs
@@ -5,7 +5,7 @@ defmodule ExampleCliApp.MixProject do
     [
       app: :example_cli_app,
       releases: releases(),
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps()
@@ -20,10 +20,8 @@ defmodule ExampleCliApp.MixProject do
           targets: [
             macos: [os: :darwin, cpu: :x86_64],
             macos_m1: [os: :darwin, cpu: :aarch64],
-            linux_gnu: [os: :linux, cpu: :x86_64, libc: :gnu],
-            linux_musl: [os: :linux, cpu: :x86_64, libc: :musl],
-            linux_gnu_aarch64: [os: :linux, cpu: :aarch64, libc: :gnu],
-            linux_musl_aarch64: [os: :linux, cpu: :aarch64, libc: :musl],
+            linux: [os: :linux, cpu: :x86_64],
+            linux_aarch64: [os: :linux, cpu: :aarch64],
             windows: [os: :windows, cpu: :x86_64]
           ],
           extra_steps: [

--- a/examples/only_one/mix.exs
+++ b/examples/only_one/mix.exs
@@ -21,7 +21,7 @@ defmodule OnlyOne.MixProject do
             macos: [os: :darwin, cpu: :x86_64],
             macos_m1: [os: :darwin, cpu: :aarch64],
             linux: [os: :linux, cpu: :x86_64],
-            linux_musl: [os: :linux, cpu: :x86_64, libc: :musl],
+            linux_aarch64: [os: :linux, cpu: :aarch64],
             # windows: [os: :windows, cpu: :x86_64] Windows not supported on this one, sorry :(
           ],
           debug: Mix.env() != :prod,

--- a/examples/phx_app/mix.exs
+++ b/examples/phx_app/mix.exs
@@ -60,10 +60,8 @@ defmodule PhxApp.MixProject do
           targets: [
             macos: [os: :darwin, cpu: :x86_64],
             macos_m1: [os: :darwin, cpu: :aarch64],
-            linux_gnu: [os: :linux, cpu: :x86_64, libc: :gnu],
-            linux_musl: [os: :linux, cpu: :x86_64, libc: :musl],
-            linux_gnu_aarch64: [os: :linux, cpu: :aarch64, libc: :gnu],
-            linux_musl_aarch64: [os: :linux, cpu: :aarch64, libc: :musl],
+            linux: [os: :linux, cpu: :x86_64],
+            linux_aarch64: [os: :linux, cpu: :aarch64],
             windows: [os: :windows, cpu: :x86_64]
           ],
           debug: Mix.env() != :prod

--- a/lib/builder/builder.ex
+++ b/lib/builder/builder.ex
@@ -42,7 +42,7 @@ defmodule Burrito.Builder do
   """
 
   @phases [
-    fetch: [Fetch.Init, Fetch.ResolveERTS],
+    fetch: [Fetch.Init, Fetch.FetchMusl, Fetch.ResolveERTS],
     patch: [Patch.CopyERTS, Patch.RecompileNIFs],
     build: [Build.PackAndBuild, Build.CopyRelease]
   ]
@@ -102,6 +102,7 @@ defmodule Burrito.Builder do
         mix_release: release,
         work_dir: "",
         self_dir: self_path,
+        extra_build_env: [],
         halted: false
       }
 

--- a/lib/builder/context.ex
+++ b/lib/builder/context.ex
@@ -10,6 +10,7 @@ defmodule Burrito.Builder.Context do
     field(:mix_release, Mix.Release.t())
     field(:work_dir, String.t())
     field(:self_dir, String.t())
+    field(:extra_build_env, list({String.t(), String.t()}))
     field(:halted, boolean())
   end
 end

--- a/lib/builder/target.ex
+++ b/lib/builder/target.ex
@@ -70,7 +70,8 @@ defmodule Burrito.Builder.Target do
   end
 
   defp is_cross_build?(fields) do
-    fields[:os] != Util.get_current_os() || fields[:cpu] != Util.get_current_cpu()
+    fields[:os] != Util.get_current_os() || fields[:cpu] != Util.get_current_cpu() or
+      fields[:os] == :linux
   end
 
   @spec make_triplet(Burrito.Builder.Target.t()) :: String.t()

--- a/lib/steps/build/pack_and_build.ex
+++ b/lib/steps/build/pack_and_build.ex
@@ -30,7 +30,7 @@ defmodule Burrito.Steps.Build.PackAndBuild do
       {"__BURRITO_RELEASE_PATH", context.work_dir},
       {"__BURRITO_RELEASE_NAME", release_name},
       {"__BURRITO_PLUGIN_PATH", plugin_path}
-    ]
+    ] ++ context.extra_build_env
 
     Log.info(:step, "Zig build env: #{inspect(build_env)}")
 
@@ -99,12 +99,14 @@ defmodule Burrito.Steps.Build.PackAndBuild do
     out = Path.join(self_path, "zig-out")
     payload = Path.join(self_path, "payload.foilz")
     compressed_payload = Path.join(self_path, ["src/", "payload.foilz.xz"])
+    musl_runtime = Path.join(self_path, ["src/", "musl-runtime.so"])
     metadata = Path.join(self_path, ["src/", "_metadata.json"])
 
     File.rmdir(cache)
     File.rmdir(out)
     File.rm(payload)
     File.rm(compressed_payload)
+    File.rm(musl_runtime)
     File.rm(metadata)
 
     :ok

--- a/lib/steps/build/pack_and_build.ex
+++ b/lib/steps/build/pack_and_build.ex
@@ -25,12 +25,13 @@ defmodule Burrito.Steps.Build.PackAndBuild do
     # File system to suddenly "wake up" to all the files inside it.
     Path.join(context.work_dir, ["/lib", "/.burrito"]) |> File.touch!()
 
-    build_env = [
-      {"__BURRITO_IS_PROD", is_prod(context.target)},
-      {"__BURRITO_RELEASE_PATH", context.work_dir},
-      {"__BURRITO_RELEASE_NAME", release_name},
-      {"__BURRITO_PLUGIN_PATH", plugin_path}
-    ] ++ context.extra_build_env
+    build_env =
+      [
+        {"__BURRITO_IS_PROD", is_prod(context.target)},
+        {"__BURRITO_RELEASE_PATH", context.work_dir},
+        {"__BURRITO_RELEASE_NAME", release_name},
+        {"__BURRITO_PLUGIN_PATH", plugin_path}
+      ] ++ context.extra_build_env
 
     Log.info(:step, "Zig build env: #{inspect(build_env)}")
 

--- a/lib/steps/fetch/fetch_musl.ex
+++ b/lib/steps/fetch/fetch_musl.ex
@@ -1,0 +1,73 @@
+defmodule Burrito.Steps.Fetch.FetchMusl do
+  alias Burrito.Builder.Context
+  alias Burrito.Builder.Log
+  alias Burrito.Builder.Step
+  alias Burrito.Builder.Target
+
+  alias Burrito.Util.FileCache
+
+  @linux_musl_url "https://beam-machine-universal.b-cdn.net/musl/libc-musl-{HASH}.so"
+  @linux_musl_runtime_x86_64 "17613ec13d9aa9e5e907e6750785c5bbed3ad49472ec12281f592e2f0f2d3dbd"
+  @linux_musl_runtime_aarch64 "939d11dcd3b174a8dee05047f2ae794c5c43af54720c352fa946cd8b0114627a"
+
+  @please_do_not_abuse_these_downloads_bandwidth_costs_money "?please-respect-my-bandwidth-costs=thank-you"
+
+  @behaviour Step
+
+  @impl Step
+  def execute(
+        %Context{target: %Target{os: :linux, cpu: arch, erts_source: {:precompiled, _}} = _target} =
+          context
+      ) do
+    Log.info(:step, "Fetching musl libc runtime binary for Linux...")
+
+    so_url = fetch_musl_runtime(arch) |> to_string()
+    cache_key = :crypto.hash(:sha, so_url) |> Base.encode16()
+
+    so_bytes =
+      case FileCache.fetch(cache_key) do
+        {:hit, data} ->
+          Log.info(:step, "Found matching cached musl runtime, using that")
+          data
+
+        _ ->
+          do_download(so_url, cache_key)
+      end
+
+    out_path = Path.join([context.self_dir, "src", "musl-runtime.so"])
+    File.write!(out_path, so_bytes)
+
+    Log.success(:step, "Wrote musl runtime file: #{out_path}")
+
+    %Context{
+      context
+      | extra_build_env:
+          context.extra_build_env ++
+            [{"__BURRITO_MUSL_RUNTIME_PATH", "/tmp/libc-musl-#{get_runtime_hash(arch)}.so"}]
+    }
+  end
+
+  def execute(context), do: context
+
+  defp do_download(url, cache_key) do
+    {:ok, _} = Application.ensure_all_started(:req)
+    Log.info(:step, "Downloading file: #{url}")
+    resp = Req.get!(url, raw: true)
+
+    if resp.status != 200 do
+      raise "Failed to fetch musl runtime: #{url}! (Got #{resp.status}) -- please file an issue! Thanks!"
+    end
+
+    FileCache.put_if_not_exist(cache_key, resp.body)
+    resp.body
+  end
+
+  defp fetch_musl_runtime(arch) do
+    (String.replace(@linux_musl_url, "{HASH}", get_runtime_hash(arch)) <>
+       @please_do_not_abuse_these_downloads_bandwidth_costs_money)
+    |> URI.parse()
+  end
+
+  defp get_runtime_hash(:x86_64), do: @linux_musl_runtime_x86_64
+  defp get_runtime_hash(:aarch64), do: @linux_musl_runtime_aarch64
+end

--- a/lib/steps/fetch/resolve_erts.ex
+++ b/lib/steps/fetch/resolve_erts.ex
@@ -13,7 +13,7 @@ defmodule Burrito.Steps.Fetch.ResolveERTS do
     {:darwin, :x86_64},
     {:darwin, :aarch64},
     {:linux, :x86_64},
-    {:linux, :aarch64},
+    {:linux, :aarch64}
   ]
 
   @impl Step

--- a/lib/steps/fetch/resolve_erts.ex
+++ b/lib/steps/fetch/resolve_erts.ex
@@ -7,17 +7,13 @@ defmodule Burrito.Steps.Fetch.ResolveERTS do
 
   @behaviour Step
 
-  # A list of the pre compiled ERTS builds we provide
-  # using the `erlang-builder` repo
+  # A list of the pre-compiled ERTS builds we provide
   @pre_compiled_supported_tuples [
-    # {os, cpu, libc (linux only)}
-    {:windows, :x86_64, nil},
-    {:darwin, :x86_64, nil},
-    {:darwin, :aarch64, nil},
-    {:linux, :x86_64, :gnu},
-    {:linux, :x86_64, :musl},
-    {:linux, :aarch64, :gnu},
-    {:linux, :aarch64, :musl},
+    {:windows, :x86_64},
+    {:darwin, :x86_64},
+    {:darwin, :aarch64},
+    {:linux, :x86_64},
+    {:linux, :aarch64},
   ]
 
   @impl Step
@@ -45,8 +41,7 @@ defmodule Burrito.Steps.Fetch.ResolveERTS do
   end
 
   defp pass_precompile_check?(%Target{erts_source: {:precompiled, _}} = target) do
-    libc = Keyword.get(target.qualifiers, :libc)
-    {target.os, target.cpu, libc} in @pre_compiled_supported_tuples
+    {target.os, target.cpu} in @pre_compiled_supported_tuples
   end
 
   defp pass_precompile_check?(_) do

--- a/lib/util/default_erts_resolver.ex
+++ b/lib/util/default_erts_resolver.ex
@@ -5,7 +5,7 @@ defmodule Burrito.Util.DefaultERTSResolver do
   alias Burrito.Util
   alias Burrito.Util.FileCache
   alias Burrito.Util.ERTSResolver
-  alias Burrito.Util.ERTSBeamMachineFetcher
+  alias Burrito.Util.ERTSUniversalMachineFetcher
 
   @behaviour ERTSResolver
 
@@ -17,7 +17,7 @@ defmodule Burrito.Util.DefaultERTSResolver do
 
   def do_resolve(%Target{erts_source: {:precompiled, version: otp_version}} = target)
       when is_binary(otp_version) do
-    case ERTSBeamMachineFetcher.fetch_version(
+    case ERTSUniversalMachineFetcher.fetch_version(
            target.os,
            target.qualifiers[:libc],
            target.cpu,

--- a/lib/util/erts_beam_machine_fetcher.ex
+++ b/lib/util/erts_beam_machine_fetcher.ex
@@ -13,17 +13,21 @@ defmodule Burrito.Util.ERTSBeamMachineFetcher do
       when is_binary(otp_version) and is_atom(os) and is_atom(cpu) and is_atom(libc) do
     {:ok, _} = Application.ensure_all_started(:req)
 
-    final_url = case os do
-      :darwin ->
-        @mac_url <> @please_do_not_abuse_these_downloads_bandwidth_costs_money
-      :linux ->
-        @linux_url <> @please_do_not_abuse_these_downloads_bandwidth_costs_money
-      :windows -> @windows_url
-    end
-    |> String.replace("{OTP_VERSION}", otp_version)
-    |> String.replace("{ARCH}", Atom.to_string(cpu))
-    |> String.replace("{LIBC}", Atom.to_string(libc))
-    |> String.replace("{OPENSSL_VERSION}", @beam_machine_openssl_version)
+    final_url =
+      case os do
+        :darwin ->
+          @mac_url <> @please_do_not_abuse_these_downloads_bandwidth_costs_money
+
+        :linux ->
+          @linux_url <> @please_do_not_abuse_these_downloads_bandwidth_costs_money
+
+        :windows ->
+          @windows_url
+      end
+      |> String.replace("{OTP_VERSION}", otp_version)
+      |> String.replace("{ARCH}", Atom.to_string(cpu))
+      |> String.replace("{LIBC}", Atom.to_string(libc))
+      |> String.replace("{OPENSSL_VERSION}", @beam_machine_openssl_version)
 
     Log.success(:step, "Remote ERTS From Beam Machine: #{final_url}")
 

--- a/lib/util/erts_universal_machine_fetcher.ex
+++ b/lib/util/erts_universal_machine_fetcher.ex
@@ -1,0 +1,35 @@
+defmodule Burrito.Util.ERTSUniversalMachineFetcher do
+  alias Burrito.Builder.Log
+
+  @beam_machine_openssl_version "3.1.4"
+  @windows_url "https://github.com/erlang/otp/releases/download/OTP-{OTP_VERSION}/otp_win64_{OTP_VERSION}.exe"
+  @linux_url "https://beam-machine-universal.b-cdn.net/OTP-{OTP_VERSION}/linux/{ARCH}/any/otp_{OTP_VERSION}_linux_any_{ARCH}_ssl_{OPENSSL_VERSION}.tar.gz"
+  @mac_url "https://beam-machine-universal.b-cdn.net/OTP-{OTP_VERSION}/macos/universal/otp_{OTP_VERSION}_macos_universal_ssl_{OPENSSL_VERSION}.tar.gz"
+
+  @please_do_not_abuse_these_downloads_bandwidth_costs_money "?please-respect-my-bandwidth-costs=thank-you"
+
+  @spec fetch_version(atom(), atom(), atom(), String.t()) :: URI.t() | {:error, atom()}
+  def fetch_version(os, _libc, cpu, otp_version)
+      when is_binary(otp_version) and is_atom(os) and is_atom(cpu) do
+    {:ok, _} = Application.ensure_all_started(:req)
+
+    final_url =
+      case os do
+        :darwin ->
+          @mac_url <> @please_do_not_abuse_these_downloads_bandwidth_costs_money
+
+        :linux ->
+          @linux_url <> @please_do_not_abuse_these_downloads_bandwidth_costs_money
+
+        :windows ->
+          @windows_url
+      end
+      |> String.replace("{OTP_VERSION}", otp_version)
+      |> String.replace("{ARCH}", Atom.to_string(cpu))
+      |> String.replace("{OPENSSL_VERSION}", @beam_machine_openssl_version)
+
+    Log.success(:step, "Remote ERTS From Beam Machine: #{final_url}")
+
+    URI.parse(final_url)
+  end
+end

--- a/lib/util/util.ex
+++ b/lib/util/util.ex
@@ -8,20 +8,6 @@ defmodule Burrito.Util do
     end
   end
 
-  @spec get_libc_type :: :gnu | :musl | nil
-  def get_libc_type do
-    if get_current_os() != :linux do
-      nil
-    else
-      {result, _} = System.cmd("ldd", ["--version"])
-
-      cond do
-        String.contains?(result, "musl") -> :musl
-        true -> :gnu
-      end
-    end
-  end
-
   def get_current_cpu do
     arch_string =
       :erlang.system_info(:system_architecture)


### PR DESCRIPTION
* Changes how we pull pre-compiled OTP builds, now sourcing from the Universal BEAM Machine that allows less configurations per platform. (MacOS now has 1, Linux has 2)
* Removes the `libc` qualifier from the build context, we always use musl now.
* Auto-packs and auto-extracts a pre-compiled musl LibC runtime file at startup into `/tmp` which is utilized by the VM at runtime.
* Updates the `README` file
  * Reflects that we no longer need to specify `libc` as a build qualifier.
  * Updates that we finally _do_ support Apple Silicon.
  * Clarifies our supported OTP versions.
* Expands the tests in `example_cli` to be a lot more interesting
  * Tries to use `crypto` NIF to generate a key pair, exercising the OpenSSL integration.
  * Tries to use `exqlite` to do some common example db operations, exercising a third-party NIF.