### PR TITLE
Add utility functions for usage in standalone and non-standalone contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ end
 If you wish you retrieve the argv passed to your program by Burrito use this snippet:
 
 ```elixir
-args = Burrito.Util.Args.get_arguments() # this returns a list of strings
+args = Burrito.Util.Args.argv() # this returns a list of strings
 ```
 
 #### Maintenance Commands

--- a/lib/util/args.ex
+++ b/lib/util/args.ex
@@ -1,11 +1,28 @@
 defmodule Burrito.Util.Args do
   @moduledoc """
-  This module provides a method to help fetch CLI arguments passed down
-  from the Zig wrapper binary.
+  This module provides a method to help fetch CLI arguments, whether passed down
+  from the Zig wrapper binary or from the the system.
   """
 
+  @doc """
+  Get CLI arguments passed down from the Zig wrapper binary. Do note that this will get OTP
+  runtime arguments when called outside of a Burrito-built context. You may consider
+  `argv/0` as a more general alternative.
+  """
   @spec get_arguments :: list(String.t())
   def get_arguments do
     :init.get_plain_arguments() |> Enum.map(&to_string/1)
+  end
+
+  @doc """
+  Get the arguments from the CLI, regardless if run under Burrito or not.
+  """
+  @spec argv :: list(String.t())
+  def argv do
+    if Burrito.Util.running_standalone?() do
+      get_arguments()
+    else
+      System.argv()
+    end
   end
 end

--- a/lib/util/util.ex
+++ b/lib/util/util.ex
@@ -38,4 +38,13 @@ defmodule Burrito.Util do
 
     String.trim(otp_version)
   end
+
+  @doc """
+  Checks if the application is currently running as a standalone Burrito release, or via some other mechanism,
+  such as an `escript`.
+  """
+  @spec running_standalone?() :: boolean()
+  def running_standalone?() do
+    System.get_env("__BURRITO") != nil
+  end
 end


### PR DESCRIPTION
As a followup to #131 (thank you!), I threw together two quick changes

1. A function that checks the new `__BURRITO` environment variable, allowing applications to change their behavior based on context
2. A function, `argv`, which allows applications to get arguments regardless of context. I considered just building this into the existing `get_arguments` function, but it would technically be a breaking change (though I'd be surprised if anyone used it for its current functionality outside a standalone context). Please do let me know if you would prefer to just bite the bullet here :) 