### PR TITLE
Zig 0.13.0

### DIFF
--- a/.github/workflows/burrito-xcomp-check.yaml
+++ b/.github/workflows/burrito-xcomp-check.yaml
@@ -20,7 +20,7 @@ jobs:
           elixir-version: 1.16.2
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.11.0
+          version: 0.13.0
       - name: Set up Homebrew
         if: matrix.host == 'macos-latest'
         id: set-up-homebrew

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ Temporary Items
 
 zig-cache/
 zig-out/
+**.zig-cache/**
 build-*/
 docgen_tmp/
 
@@ -52,3 +53,4 @@ erl_crash.dump
 /config/*.secret.exs
 .elixir_ls/
 **/burrito_out/**
+

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-zig 0.11.0
-erlang 26.1.2
-elixir 1.15.6-otp-26
+zig 0.13.0
+erlang 26.2.2
+elixir 1.16.1-otp-26

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ We support _targeting_ Windows (x86_64) from MacOS and Linux, we _do not_ offici
 
 You must have the following installed and in your PATH:
 
-* Zig (0.11.0) -- `zig`
+* Zig (0.13.0) -- `zig`
 * XZ -- `xz`
 * 7z -- `7z` (For Windows Targets)
 

--- a/bin/fetch_zig.sh
+++ b/bin/fetch_zig.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-ZIG_VERSION="0.11.0"
+ZIG_VERSION="0.13.0"
 
 ####
 

--- a/examples/only_one/plugin/file_check.zig
+++ b/examples/only_one/plugin/file_check.zig
@@ -6,10 +6,10 @@ pub fn burrito_plugin_entry(install_dir: []const u8, program_manifest_json: []co
     std.debug.print("Install Dir: {s}\n", .{install_dir});
     std.debug.print(": {s}\n", .{program_manifest_json});
 
-    var exists = if (std.fs.cwd().access("only_one.lock", .{ .mode = File.OpenMode.read_only })) true else |_| false;
+    const exists = if (std.fs.cwd().access("only_one.lock", .{ .mode = File.OpenMode.read_only })) true else |_| false;
 
     if (exists) {
         std.log.err("We found a lockfile! Can't run two of this application at one!\n", .{});
-        std.os.exit(1);
+        std.process.exit(0);
     }
 }

--- a/lib/burrito.ex
+++ b/lib/burrito.ex
@@ -2,7 +2,7 @@ defmodule Burrito do
   alias Burrito.Builder
   alias Burrito.Builder.Log
 
-  @zig_version_expected %Version{major: 0, minor: 11, patch: 0}
+  @zig_version_expected %Version{major: 0, minor: 13, patch: 0}
 
   @spec wrap(Mix.Release.t()) :: Mix.Release.t()
   def wrap(%Mix.Release{} = release) do

--- a/src/erlang_launcher.zig
+++ b/src/erlang_launcher.zig
@@ -21,7 +21,7 @@ fn get_erl_exe_name() []const u8 {
 
 pub fn launch(install_dir: []const u8, env_map: *EnvMap, meta: *const MetaStruct, args_trimmed: []const []const u8) !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    var allocator = arena.allocator();
+    const allocator = arena.allocator();
 
     // Computer directories we care about
     const release_cookie_path = try fs.path.join(allocator, &[_][]const u8{ install_dir, "releases", "COOKIE" });
@@ -71,7 +71,7 @@ pub fn launch(install_dir: []const u8, env_map: *EnvMap, meta: *const MetaStruct
         try env_map.put("RELEASE_SYS_CONFIG", config_sys_path_no_ext);
         try env_map.put("__BURRITO", "1");
 
-        var win_child_proc = std.ChildProcess.init(final_args, allocator);
+        var win_child_proc = std.process.Child.init(final_args, allocator);
         win_child_proc.env_map = env_map;
         win_child_proc.stdout_behavior = .Inherit;
         win_child_proc.stdin_behavior = .Inherit;

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -6,36 +6,48 @@ var allocator = arena.allocator();
 
 pub fn query(comptime message: []const u8, args: anytype) void {
     var stdout = std.io.getStdOut().writer();
-    var out_string = std.fmt.allocPrint(allocator, message, args) catch { return; };
+    const out_string = std.fmt.allocPrint(allocator, message, args) catch {
+        return;
+    };
     stdout.print("[?] {s}", .{out_string}) catch {};
 }
 
 pub fn log_stderr(comptime message: []const u8, args: anytype) void {
     var stderr = std.io.getStdErr().writer();
-    var out_string = std.fmt.allocPrint(allocator, message, args) catch { return; };
+    const out_string = std.fmt.allocPrint(allocator, message, args) catch {
+        return;
+    };
     stderr.print("[l] {s}\n", .{out_string}) catch {};
 }
 
 pub fn info(comptime message: []const u8, args: anytype) void {
     var stdout = std.io.getStdOut().writer();
-    var out_string = std.fmt.allocPrint(allocator, message, args) catch { return; };
+    const out_string = std.fmt.allocPrint(allocator, message, args) catch {
+        return;
+    };
     stdout.print("[i] {s}\n", .{out_string}) catch {};
 }
 
 pub fn warn(comptime message: []const u8, args: anytype) void {
     var stderr = std.io.getStdErr().writer();
-    var out_string = std.fmt.allocPrint(allocator, message, args) catch { return; };
+    const out_string = std.fmt.allocPrint(allocator, message, args) catch {
+        return;
+    };
     stderr.print("[w] {s}\n", .{out_string}) catch {};
 }
 
 pub fn err(comptime message: []const u8, args: anytype) void {
     var stderr = std.io.getStdErr().writer();
-    var out_string = std.fmt.allocPrint(allocator, message, args) catch { return; };
+    const out_string = std.fmt.allocPrint(allocator, message, args) catch {
+        return;
+    };
     stderr.print("[!] {s}\n", .{out_string}) catch {};
 }
 
 pub fn crit(comptime message: []const u8, args: anytype) void {
     var stderr = std.io.getStdErr().writer();
-    var out_string = std.fmt.allocPrint(allocator, message, args) catch { return; };
+    const out_string = std.fmt.allocPrint(allocator, message, args) catch {
+        return;
+    };
     stderr.print("[!!] {s}\n", .{out_string}) catch {};
 }

--- a/src/maintenance.zig
+++ b/src/maintenance.zig
@@ -72,7 +72,7 @@ pub fn do_clean_old_versions(install_prefix_path: []const u8, current_install_pa
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const prefix_dir = try std.fs.openIterableDirAbsolute(install_prefix_path, .{ .access_sub_paths = true });
+    const prefix_dir = try std.fs.openDirAbsolute(install_prefix_path, .{ .access_sub_paths = true, .iterate = true });
 
     const current_install = try install.load_install_from_path(allocator, current_install_path);
 

--- a/src/wrapper.zig
+++ b/src/wrapper.zig
@@ -57,8 +57,8 @@ pub fn main() anyerror!void {
         var windows_arg_list = std.ArrayList([]u8).init(allocator);
         var i: usize = 0;
         while (i < arg_count) : (i += 1) {
-            var index = i;
-            var length = std.mem.len(raw_args.?[index]);
+            const index = i;
+            const length = std.mem.len(raw_args.?[index]);
             const argument = try std.unicode.utf16leToUtf8Alloc(allocator, raw_args.?[index][0..length]);
             try windows_arg_list.append(argument);
         }
@@ -165,7 +165,7 @@ fn get_base_install_dir() ![]const u8 {
         logger.info("New install path is: {s}", .{new_path});
         return try fs.path.join(allocator, &[_][]const u8{ new_path, install_suffix });
     } else |err| switch (err) {
-        error.InvalidUtf8 => {},
+        error.InvalidWtf8 => {},
         error.EnvironmentVariableNotFound => {},
         error.OutOfMemory => {},
     }
@@ -220,8 +220,8 @@ fn maybe_install_musl_runtime() anyerror!void {
     if (comptime IS_LINUX and !std.mem.eql(u8, build_options.MUSL_RUNTIME_PATH, "")) {
         // Check if the file was already extracted
         const cStr = try allocator.dupeZ(u8, build_options.MUSL_RUNTIME_PATH);
-        var statBuffer: std.os.Stat = undefined;
-        const statResult = std.os.system.stat(cStr, &statBuffer);
+        var statBuffer: std.c.Stat = undefined;
+        const statResult = std.c.stat(cStr, &statBuffer);
 
         if (statResult == 0) {
             // File exists


### PR DESCRIPTION
* Update to Zig `0.13.0`.
* Update plugins and example code.
* Update wrapper and launcher code to work with Zig `0.13.0`.