### PR TITLE
Relax requirement on Req

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule Burrito.MixProject do
 
   defp deps do
     [
-      {:req, "0.4.0"},
+      {:req, ">= 0.4.0"},
       {:typed_struct, "~> 0.2.0 or ~> 0.3.0", runtime: false},
       {:jason, "~> 1.2"},
       {:ex_doc, ">= 0.0.0", only: :dev}


### PR DESCRIPTION
Even though Req is pre-1.0, the core parts of the API are generally stable, so given that Burrito isn't using any advanced features of Req, IMO the requirement for it can be relaxed. It will allow Burrito users to depend on newer versions of Req without Burrito updating it each time.

I checked the Req docs and it shouldn't break anything, wanted to verify by compiling `cli_example`, but it fails on main with

```
----> PHASE: :fetch
Custom build step!
Current Target: %Burrito.Builder.Target{debug?: true, erts_source: {:precompiled, [version: "26.2.5"]}, qualifiers: [], cross_build: true, os: :windows, cpu: :x86_64, alias: :windows}
--> Working directory: /var/folders/yd/26zlwh3n7m36yfpfjx60rkp40000gn/T/burrito_build_2A5F93534D4E717B
--> Resolving ERTS: {:precompiled, [version: "26.2.5"]}
--> Remote ERTS From Beam Machine: https://github.com/erlang/otp/releases/download/OTP-26.2.5/otp_win64_26.2.5.exe
--> Found matching cached ERTS, using that
--> Unpacked ERTS to: /var/folders/yd/26zlwh3n7m36yfpfjx60rkp40000gn/T/unpacked_erts_7837F3363850AEC0
----> PHASE: :patch
--> Replacing ERTS binaries...
** (FunctionClauseError) no function clause matching in IO.chardata_to_string/1

    The following arguments were given to IO.chardata_to_string/1:

        # 1
        nil

    Attempted function clauses (showing 2 out of 2):

        def chardata_to_string(string) when is_binary(string)
        def chardata_to_string(list) when is_list(list)

    (elixir 1.16.3) lib/io.ex:687: IO.chardata_to_string/1
    (elixir 1.16.3) lib/path.ex:662: Path.join/2
    (burrito 1.1.0) lib/steps/patch/copy_erts.ex:42: Burrito.Steps.Patch.CopyERTS.do_copy/2
    (burrito 1.1.0) lib/steps/patch/copy_erts.ex:20: Burrito.Steps.Patch.CopyERTS.execute/1
    (burrito 1.1.0) lib/builder/builder.ex:140: anonymous fn/3 in Burrito.Builder.run_phase/2
    (elixir 1.16.3) lib/enum.ex:2528: Enum."-reduce/3-lists^foldl/2-0-"/3
    (elixir 1.16.3) lib/enum.ex:987: Enum."-each/2-lists^foreach/1-0-"/2
    (burrito 1.1.0) lib/builder/builder.ex:88: Burrito.Builder.build/1
```