### PR TITLE
Add utility function to fetch wrapper exe path at runtime

### DIFF
--- a/examples/cli_example/lib/example_cli_app.ex
+++ b/examples/cli_example/lib/example_cli_app.ex
@@ -3,6 +3,7 @@ defmodule ExampleCliApp do
     args = Burrito.Util.Args.get_arguments()
 
     IO.puts("My arguments are: #{inspect(args)}")
+    IO.puts("I was started from: #{Burrito.Util.Args.get_bin_path()}")
 
     IO.write("Testing Crypto (Generating ed25519 key-pair)...")
     test_crypto()

--- a/lib/util/args.ex
+++ b/lib/util/args.ex
@@ -25,4 +25,18 @@ defmodule Burrito.Util.Args do
       System.argv()
     end
   end
+
+  @doc """
+  Returns the path of the wrapper binary that launched this application.
+  If not currently inside a Burrito wrapped application, returns `:not_in_burrito`.
+  """
+  @spec get_bin_path() :: binary() | :not_in_burrito
+  def get_bin_path() do
+    env_value = System.get_env("__BURRITO_BIN_PATH")
+    if env_value != nil do
+      env_value
+    else
+      :not_in_burrito
+    end
+  end
 end

--- a/src/erlang_launcher.zig
+++ b/src/erlang_launcher.zig
@@ -19,7 +19,7 @@ fn get_erl_exe_name() []const u8 {
     }
 }
 
-pub fn launch(install_dir: []const u8, env_map: *EnvMap, meta: *const MetaStruct, args_trimmed: []const []const u8) !void {
+pub fn launch(install_dir: []const u8, env_map: *EnvMap, meta: *const MetaStruct, self_path: []const u8, args_trimmed: []const []const u8) !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     const allocator = arena.allocator();
 
@@ -70,6 +70,7 @@ pub fn launch(install_dir: []const u8, env_map: *EnvMap, meta: *const MetaStruct
         try env_map.put("RELEASE_ROOT", install_dir);
         try env_map.put("RELEASE_SYS_CONFIG", config_sys_path_no_ext);
         try env_map.put("__BURRITO", "1");
+        try env_map.put("__BURRITO_BIN_PATH", self_path);
 
         var win_child_proc = std.process.Child.init(final_args, allocator);
         win_child_proc.env_map = env_map;
@@ -105,6 +106,7 @@ pub fn launch(install_dir: []const u8, env_map: *EnvMap, meta: *const MetaStruct
         try erl_env_map.put("RELEASE_ROOT", install_dir);
         try erl_env_map.put("RELEASE_SYS_CONFIG", config_sys_path_no_ext);
         try erl_env_map.put("__BURRITO", "1");
+        try erl_env_map.put("__BURRITO_BIN_PATH", self_path);
 
         return std.process.execve(allocator, final_args, &erl_env_map);
     }

--- a/src/wrapper.zig
+++ b/src/wrapper.zig
@@ -73,6 +73,7 @@ pub fn main() anyerror!void {
     try maybe_install_musl_runtime();
 
     // Trim args to only what we actually want to pass to erlang
+    const self_path = try std.fs.selfExePathAlloc(allocator);
     const args_trimmed = args.?[1..];
 
     // If this is not a production build, we always want a clean install
@@ -142,7 +143,7 @@ pub fn main() anyerror!void {
 
     log.debug("Launching erlang...", .{});
 
-    try launcher.launch(install_dir, &env_map, &meta, args_trimmed);
+    try launcher.launch(install_dir, &env_map, &meta, self_path, args_trimmed);
 }
 
 fn do_payload_install(install_dir: []const u8, metadata_path: []const u8) !void {


### PR DESCRIPTION
Addresses #143 

```elixir
# This will return the current exe path of the wrapped binary at runtime
Burrito.Util.Args.get_bin_path()
```