### PR TITLE
Use 7zz if available

### DIFF
--- a/lib/burrito.ex
+++ b/lib/burrito.ex
@@ -24,10 +24,10 @@ defmodule Burrito do
       exit(1)
     end
 
-    if Enum.any?(~w(7z), &(System.find_executable(&1) == nil)) do
+    if Enum.any?(~w(7z 7zz), &(System.find_executable(&1) == nil)) do
       Log.warning(
         :build,
-        "We couldn't find 7z in your PATH, 7z is required to build Windows releases. They will fail if you don't fix this!"
+        "We couldn't find 7z/7zz in your PATH, 7z/7zz is required to build Windows releases. They will fail if you don't fix this!"
       )
     end
 

--- a/lib/util/default_erts_resolver.ex
+++ b/lib/util/default_erts_resolver.ex
@@ -70,10 +70,16 @@ defmodule Burrito.Util.DefaultERTSResolver do
     extraction_path = System.tmp_dir!() |> Path.join(["unpacked_erts_#{random_id}"])
     File.mkdir_p!(extraction_path)
 
+    seven_z =
+      with nil <- System.find_executable("7zz"),
+           nil <- System.find_executable("7z") do
+        raise "Couldn't find 7z/7zz"
+      end
+
     # we use 7z to unpack windows setup files, otherwise we use tar
     command =
       case target.os do
-        :windows -> ~c"7z x #{tar_dest_path} -o#{extraction_path}/otp-windows/"
+        :windows -> ~c"#{seven_z} x #{tar_dest_path} -o#{extraction_path}/otp-windows/"
         _ -> ~c"tar xzf #{tar_dest_path} -C #{extraction_path}"
       end
 


### PR DESCRIPTION
Seems like package managers are distributing this package as 7zz instead
of 7z.
