### PR TITLE
Introduce auto_confirmed option for 'maintenance uninstall' task

### DIFF
--- a/src/maintenance.zig
+++ b/src/maintenance.zig
@@ -11,12 +11,9 @@ pub fn do_maint(args: [][]u8, install_dir: []const u8) !void {
     if (args.len < 1) {
         logger.warn("No sub-command provided!", .{});
     } else {
-        if (std.mem.eql(u8, args[0], "uninstall_yes")) {
-            try do_uninstall_confirmed(install_dir);
-        }
-
         if (std.mem.eql(u8, args[0], "uninstall")) {
-            try do_uninstall(install_dir);
+            const confirmed = args.len >= 2 and std.mem.eql(u8, args[1], "confirmed");
+            try do_uninstall(install_dir, confirmed);
         }
 
         if (std.mem.eql(u8, args[0], "directory")) {
@@ -45,12 +42,14 @@ fn confirm() !bool {
     }
 }
 
-fn do_uninstall(install_dir: []const u8) !void {
-    logger.warn("This will uninstall the application runtime for this Burrito binary!", .{});
-    if ((try confirm()) == false) {
-        logger.warn("Uninstall was aborted!", .{});
-        logger.info("Quitting.", .{});
-        return;
+fn do_uninstall(install_dir: []const u8, auto_confirmed: bool) !void {
+    if (!auto_confirmed) {
+        logger.warn("This will uninstall the application runtime for this Burrito binary!", .{});
+        if ((try confirm()) == false) {
+            logger.warn("Uninstall was aborted!", .{});
+            logger.info("Quitting.", .{});
+            return;
+        }
     }
 
     logger.info("Deleting directory: {s}", .{install_dir});

--- a/src/maintenance.zig
+++ b/src/maintenance.zig
@@ -11,6 +11,10 @@ pub fn do_maint(args: [][]u8, install_dir: []const u8) !void {
     if (args.len < 1) {
         logger.warn("No sub-command provided!", .{});
     } else {
+        if (std.mem.eql(u8, args[0], "uninstall_yes")) {
+            try do_uninstall_confirmed(install_dir);
+        }
+
         if (std.mem.eql(u8, args[0], "uninstall")) {
             try do_uninstall(install_dir);
         }
@@ -49,6 +53,13 @@ fn do_uninstall(install_dir: []const u8) !void {
         return;
     }
 
+    logger.info("Deleting directory: {s}", .{install_dir});
+    try std.fs.deleteTreeAbsolute(install_dir);
+    logger.info("Uninstall complete!", .{});
+    logger.info("Quitting.", .{});
+}
+
+fn do_uninstall_confirmed(install_dir: []const u8) !void {
     logger.info("Deleting directory: {s}", .{install_dir});
     try std.fs.deleteTreeAbsolute(install_dir);
     logger.info("Uninstall complete!", .{});


### PR DESCRIPTION
Usecase: 

In some automated scenario, there is a need to override the cached build with a new build of the _same version_, without user having to type `y` when prompted. For example, re-deploy a build in a local test env.