### PR TITLE
fix: Move `seven_z` check under `target.os` `:windows`

### DIFF
--- a/lib/util/default_erts_resolver.ex
+++ b/lib/util/default_erts_resolver.ex
@@ -70,17 +70,20 @@ defmodule Burrito.Util.DefaultERTSResolver do
     extraction_path = System.tmp_dir!() |> Path.join(["unpacked_erts_#{random_id}"])
     File.mkdir_p!(extraction_path)
 
-    seven_z =
-      with nil <- System.find_executable("7zz"),
-           nil <- System.find_executable("7z") do
-        raise "Couldn't find 7z/7zz"
-      end
-
     # we use 7z to unpack windows setup files, otherwise we use tar
     command =
       case target.os do
-        :windows -> ~c"#{seven_z} x #{tar_dest_path} -o#{extraction_path}/otp-windows/"
-        _ -> ~c"tar xzf #{tar_dest_path} -C #{extraction_path}"
+        :windows ->
+          seven_z =
+            with nil <- System.find_executable("7zz"),
+                 nil <- System.find_executable("7z") do
+              raise "Couldn't find 7z/7zz"
+            end
+
+          ~c"#{seven_z} x #{tar_dest_path} -o#{extraction_path}/otp-windows/"
+
+        _ ->
+          ~c"tar xzf #{tar_dest_path} -C #{extraction_path}"
       end
 
     :os.cmd(command)


### PR DESCRIPTION
Before this change on macOS, targeting only macOS, it would raise the error message `Couldn’t find 7z/7zz`.  After this change, the script will only fail when the `target.os` is `:windows` and neither `7z` nor `7zz` is found in the path.