### PR TITLE
Moved 7z validation logic to activate only if compiling on windows.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 zig 0.14.0
-erlang 27.3
+erlang 27.0
 elixir 1.18.3-otp-27

--- a/lib/util/default_erts_resolver.ex
+++ b/lib/util/default_erts_resolver.ex
@@ -70,17 +70,20 @@ defmodule Burrito.Util.DefaultERTSResolver do
     extraction_path = System.tmp_dir!() |> Path.join(["unpacked_erts_#{random_id}"])
     File.mkdir_p!(extraction_path)
 
-    seven_z =
-      with nil <- System.find_executable("7zz"),
-           nil <- System.find_executable("7z") do
-        raise "Couldn't find 7z/7zz"
-      end
-
     # we use 7z to unpack windows setup files, otherwise we use tar
     command =
       case target.os do
-        :windows -> ~c"#{seven_z} x #{tar_dest_path} -o#{extraction_path}/otp-windows/"
-        _ -> ~c"tar xzf #{tar_dest_path} -C #{extraction_path}"
+        :windows ->
+          seven_z =
+            with nil <- System.find_executable("7zz"),
+                 nil <- System.find_executable("7z") do
+              raise "Couldn't find 7z/7zz"
+            end
+
+          ~c"#{seven_z} x #{tar_dest_path} -o#{extraction_path}/otp-windows/"
+
+        _ ->
+          ~c"tar xzf #{tar_dest_path} -C #{extraction_path}"
       end
 
     :os.cmd(command)


### PR DESCRIPTION
Updated unpack logic in `Burrito.Util.DefaultERTSResolver` module to only raise an exception for 7z/7zz not being present if the user is trying to build to a windows target.

Tested successfully on a mac without 7z.  Did not test with 7z to successfully build to a Windows target.