### PR TITLE
Bump Zig to 0.14.1

### DIFF
--- a/.github/workflows/burrito-xcomp-check.yaml
+++ b/.github/workflows/burrito-xcomp-check.yaml
@@ -20,7 +20,7 @@ jobs:
           elixir-version: "1.18.3"
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.14.0
+          version: 0.14.1
       - name: Set up Homebrew
         if: matrix.host == 'macos-latest'
         id: set-up-homebrew

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-zig 0.14.0
+zig 0.14.1
 erlang 27.3
 elixir 1.18.3-otp-27

--- a/lib/burrito.ex
+++ b/lib/burrito.ex
@@ -2,7 +2,7 @@ defmodule Burrito do
   alias Burrito.Builder
   alias Burrito.Builder.Log
 
-  @zig_version_expected %Version{major: 0, minor: 14, patch: 0}
+  @zig_version_expected %Version{major: 0, minor: 14, patch: 1}
 
   @spec wrap(Mix.Release.t()) :: Mix.Release.t()
   def wrap(%Mix.Release{} = release) do


### PR DESCRIPTION
Bumping Zig to the last version, all the examples seems to work on my machine (macos Sonoma on a M2 Pro).