### PR TITLE
Bump URLs to not be locked to OpenSSL versions.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 zig 0.14.1
-erlang 27.3
-elixir 1.18.3-otp-27
+erlang 28.0.2
+elixir 1.18.4-otp-28

--- a/lib/burrito.ex
+++ b/lib/burrito.ex
@@ -3,6 +3,8 @@ defmodule Burrito do
   alias Burrito.Builder.Log
 
   @zig_version_expected %Version{major: 0, minor: 14, patch: 1}
+  @openssl_version %Version{major: 3, minor: 5, patch: 1}
+  @musl_version %Version{major: 1, minor: 2, patch: 5}
 
   @spec wrap(Mix.Release.t()) :: Mix.Release.t()
   def wrap(%Mix.Release{} = release) do
@@ -10,8 +12,18 @@ defmodule Burrito do
     Builder.build(release)
   end
 
+  @spec register_erts_resolver(module()) :: :ok
   def register_erts_resolver(module) when is_atom(module) do
     Application.put_env(:burrito, :erts_resolver, module)
+  end
+
+  @spec get_versions() :: map()
+  def get_versions() do
+    %{
+      zig: @zig_version_expected,
+      openssl: @openssl_version,
+      musl: @musl_version
+    }
   end
 
   defp pre_check() do

--- a/lib/steps/fetch/fetch_musl.ex
+++ b/lib/steps/fetch/fetch_musl.ex
@@ -6,9 +6,10 @@ defmodule Burrito.Steps.Fetch.FetchMusl do
 
   alias Burrito.Util.FileCache
 
+  # Linked against musl libc v1.2.5
   @linux_musl_url "https://beam-machine-universal.b-cdn.net/musl/libc-musl-{HASH}.so"
-  @linux_musl_runtime_x86_64 "17613ec13d9aa9e5e907e6750785c5bbed3ad49472ec12281f592e2f0f2d3dbd"
-  @linux_musl_runtime_aarch64 "939d11dcd3b174a8dee05047f2ae794c5c43af54720c352fa946cd8b0114627a"
+  @linux_musl_runtime_x86_64 "71c35316aff45bbfd243d8eb9bfc4a58b6eb97cee09514cd2030e145b68107fb"
+  @linux_musl_runtime_aarch64 "6b558025200a5ed1308e2ce2675217afec71b6c5a9d561e52262ca948d59905e"
 
   @please_do_not_abuse_these_downloads_bandwidth_costs_money "?please-respect-my-bandwidth-costs=thank-you"
 

--- a/lib/steps/fetch/init.ex
+++ b/lib/steps/fetch/init.ex
@@ -9,7 +9,7 @@ defmodule Burrito.Steps.Fetch.Init do
   def execute(%Context{} = context) do
     random_id = :crypto.strong_rand_bytes(8) |> Base.encode16()
     work_dir = System.tmp_dir!() |> Path.join(["burrito_build_#{random_id}"])
-    File.cp_r(context.mix_release.path, work_dir, fn _, _ -> true end)
+    File.cp_r(context.mix_release.path, work_dir)
 
     Log.info(:step, "Working directory: #{work_dir}")
 

--- a/lib/util/erts_universal_machine_fetcher.ex
+++ b/lib/util/erts_universal_machine_fetcher.ex
@@ -1,10 +1,9 @@
 defmodule Burrito.Util.ERTSUniversalMachineFetcher do
   alias Burrito.Builder.Log
 
-  @beam_machine_openssl_version "3.1.4"
   @windows_url "https://github.com/erlang/otp/releases/download/OTP-{OTP_VERSION}/otp_win64_{OTP_VERSION}.exe"
-  @linux_url "https://beam-machine-universal.b-cdn.net/OTP-{OTP_VERSION}/linux/{ARCH}/any/otp_{OTP_VERSION}_linux_any_{ARCH}_ssl_{OPENSSL_VERSION}.tar.gz"
-  @mac_url "https://beam-machine-universal.b-cdn.net/OTP-{OTP_VERSION}/macos/universal/otp_{OTP_VERSION}_macos_universal_ssl_{OPENSSL_VERSION}.tar.gz"
+  @linux_url "https://beam-machine-universal.b-cdn.net/OTP-{OTP_VERSION}/linux/{ARCH}/any/otp_{OTP_VERSION}_linux_any_{ARCH}.tar.gz"
+  @mac_url "https://beam-machine-universal.b-cdn.net/OTP-{OTP_VERSION}/macos/universal/otp_{OTP_VERSION}_macos_universal.tar.gz"
 
   @please_do_not_abuse_these_downloads_bandwidth_costs_money "?please-respect-my-bandwidth-costs=thank-you"
 
@@ -26,7 +25,6 @@ defmodule Burrito.Util.ERTSUniversalMachineFetcher do
       end
       |> String.replace("{OTP_VERSION}", otp_version)
       |> String.replace("{ARCH}", Atom.to_string(cpu))
-      |> String.replace("{OPENSSL_VERSION}", @beam_machine_openssl_version)
 
     Log.success(:step, "Remote ERTS From Beam Machine: #{final_url}")
 

--- a/lib/util/erts_universal_machine_fetcher.ex
+++ b/lib/util/erts_universal_machine_fetcher.ex
@@ -15,10 +15,10 @@ defmodule Burrito.Util.ERTSUniversalMachineFetcher do
     final_url =
       case os do
         :darwin ->
-          @mac_url <> @please_do_not_abuse_these_downloads_bandwidth_costs_money
+          @mac_url <> @please_do_not_abuse_these_downloads_bandwidth_costs_money <> append_versions()
 
         :linux ->
-          @linux_url <> @please_do_not_abuse_these_downloads_bandwidth_costs_money
+          @linux_url <> @please_do_not_abuse_these_downloads_bandwidth_costs_money <> append_versions()
 
         :windows ->
           @windows_url
@@ -29,5 +29,11 @@ defmodule Burrito.Util.ERTSUniversalMachineFetcher do
     Log.success(:step, "Remote ERTS From Beam Machine: #{final_url}")
 
     URI.parse(final_url)
+  end
+
+  defp append_versions() do
+    # These are used to cache-bust when openssl or musl versions are changed upstream in the BEAM Machine build server
+    versions = Burrito.get_versions()
+    "&openssl=#{to_string(versions.openssl)}&musl=#{to_string(versions.musl)}"
   end
 end


### PR DESCRIPTION
* Updates the musl libc version linked into ERTS release to `1.2.5`:
  * Pre-built .so hash for x86_64: `71c35316aff45bbfd243d8eb9bfc4a58b6eb97cee09514cd2030e145b68107fb`
  * Pre-built .so hash for aarch64: `6b558025200a5ed1308e2ce2675217afec71b6c5a9d561e52262ca948d59905e` 
* Remove an call to deprecated `File.cp_r/3` function.
* We no longer build the OpenSSL version and musl libc versions into the file names of pre-built universal ERTS releases. Updated the modules used to fetch ERTS .tar.gz files with the new URL structure.
* Bump the versions of tools in `.tool-versions`:
  * Erlang to `28.0.2`
  * Elixir to `1.18.4-otp-28`