### PR TITLE
fix: add parentheses to module.project

### DIFF
--- a/lib/steps/patch/recompile_nifs.ex
+++ b/lib/steps/patch/recompile_nifs.ex
@@ -51,7 +51,7 @@ defmodule Burrito.Steps.Patch.RecompileNIFs do
     Enum.map(paths, fn {dep_name, path} ->
       Mix.Project.in_project(dep_name, path, fn module ->
         if module && Keyword.has_key?(module.project(), :compilers) do
-          {dep_name, path, Enum.member?(module.project[:compilers], :elixir_make)}
+          {dep_name, path, Enum.member?(module.project()[:compilers], :elixir_make)}
         else
           {dep_name, path, false}
         end


### PR DESCRIPTION
Avoids a runtime warning
