### PR TITLE
logger: use array concatenation instead of heap allocation

### DIFF
--- a/src/logger.zig
+++ b/src/logger.zig
@@ -1,53 +1,31 @@
 const std = @import("std");
 
-var log = std.log;
-var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-var allocator = arena.allocator();
-
 pub fn query(comptime message: []const u8, args: anytype) void {
     var stdout = std.io.getStdOut().writer();
-    const out_string = std.fmt.allocPrint(allocator, message, args) catch {
-        return;
-    };
-    stdout.print("[?] {s}", .{out_string}) catch {};
+    stdout.print("[?] " ++ message, args) catch {};
 }
 
 pub fn log_stderr(comptime message: []const u8, args: anytype) void {
     var stderr = std.io.getStdErr().writer();
-    const out_string = std.fmt.allocPrint(allocator, message, args) catch {
-        return;
-    };
-    stderr.print("[l] {s}\n", .{out_string}) catch {};
+    stderr.print("[l] " ++ message ++ "\n", args) catch {};
 }
 
 pub fn info(comptime message: []const u8, args: anytype) void {
     var stdout = std.io.getStdOut().writer();
-    const out_string = std.fmt.allocPrint(allocator, message, args) catch {
-        return;
-    };
-    stdout.print("[i] {s}\n", .{out_string}) catch {};
+    stdout.print("[i] " ++ message ++ "\n", args) catch {};
 }
 
 pub fn warn(comptime message: []const u8, args: anytype) void {
     var stderr = std.io.getStdErr().writer();
-    const out_string = std.fmt.allocPrint(allocator, message, args) catch {
-        return;
-    };
-    stderr.print("[w] {s}\n", .{out_string}) catch {};
+    stderr.print("[w] " ++ message ++ "\n", args) catch {};
 }
 
 pub fn err(comptime message: []const u8, args: anytype) void {
     var stderr = std.io.getStdErr().writer();
-    const out_string = std.fmt.allocPrint(allocator, message, args) catch {
-        return;
-    };
-    stderr.print("[!] {s}\n", .{out_string}) catch {};
+    stderr.print("[!] " ++ message ++ "\n", args) catch {};
 }
 
 pub fn crit(comptime message: []const u8, args: anytype) void {
     var stderr = std.io.getStdErr().writer();
-    const out_string = std.fmt.allocPrint(allocator, message, args) catch {
-        return;
-    };
-    stderr.print("[!!] {s}\n", .{out_string}) catch {};
+    stderr.print("[!!] " ++ message ++ "\n", args) catch {};
 }


### PR DESCRIPTION
There is no need to allocate the formatted string. Also the string would live as long as the process did which is unnecessary.