### PR TITLE
Relax version in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ You must have the following installed and in your PATH:
 
     ```elixir
     defp deps do
-      [{:burrito, "~> 1.0.0"}]
+      [{:burrito, "~> 1.0"}]
     end
     ```
 


### PR DESCRIPTION
This will help avoid confusion for people who are copy-pasting install instructions from the README.md. For a brief moment, I couldn't understand why `burrito` is complaining I don't a version 0.11.0 of zig installed - I had 0.15.2. Then I realized the version of `burrito` I install was an older one.