### PR TITLE
Set LD_LIBRARY_PATH on Linux for NIF shared library resolution

### DIFF
--- a/src/erlang_launcher.zig
+++ b/src/erlang_launcher.zig
@@ -118,6 +118,16 @@ pub fn launch(install_dir: []const u8, env_map: *EnvMap, meta: *const MetaStruct
         try erl_env_map.put("__BURRITO", "1");
         try erl_env_map.put("__BURRITO_BIN_PATH", self_path);
 
+        // Extend LD_LIBRARY_PATH so NIF .so files can find system shared
+        // libraries (e.g. libgcc_s.so.1) when using a custom glibc ERTS
+        const system_lib_paths = "/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:/lib:/usr/lib";
+        if (erl_env_map.get("LD_LIBRARY_PATH")) |existing| {
+            const combined = try std.fmt.allocPrint(allocator, "{s}:{s}", .{ existing, system_lib_paths });
+            try erl_env_map.put("LD_LIBRARY_PATH", combined);
+        } else {
+            try erl_env_map.put("LD_LIBRARY_PATH", system_lib_paths);
+        }
+
         return std.process.execve(allocator, final_args, &erl_env_map);
     }
 }


### PR DESCRIPTION
When using `custom_erts` with a glibc-linked ERTS (e.g. from builds.hex.pm), NIF `.so` files may depend on system shared libraries like `libgcc_s.so.1`. The BEAM process doesn't search standard system library paths by default, causing `dlopen` to fail with errors like:

```
Failed to load NIF library: 'Error loading shared library libgcc_s.so.1: No such file or directory'
```

This adds common system library paths to `LD_LIBRARY_PATH` on Linux so NIF shared objects can find their dependencies.