### PR TITLE
Add prod_envs option for custom production Mix environments

### DIFF
--- a/lib/steps/build/pack_and_build.ex
+++ b/lib/steps/build/pack_and_build.ex
@@ -27,7 +27,7 @@ defmodule Burrito.Steps.Build.PackAndBuild do
 
     build_env =
       [
-        {"__BURRITO_IS_PROD", is_prod(context.target)},
+        {"__BURRITO_IS_PROD", is_prod(context.target, options)},
         {"__BURRITO_RELEASE_PATH", context.work_dir},
         {"__BURRITO_RELEASE_NAME", release_name},
         {"__BURRITO_PLUGIN_PATH", plugin_path}
@@ -85,10 +85,12 @@ defmodule Burrito.Steps.Build.PackAndBuild do
     Path.join(self_path, ["src/", "_metadata.json"]) |> File.write!(encoded)
   end
 
-  defp is_prod(%Target{debug?: debug?}) do
+  defp is_prod(%Target{debug?: debug?}, options) do
+    prod_envs = Keyword.get(options, :prod_envs, [:prod])
+
     cond do
       debug? -> "0"
-      Mix.env() == :prod -> "1"
+      Mix.env() in prod_envs -> "1"
       true -> "0"
     end
   end


### PR DESCRIPTION
## Summary

- Add a `prod_envs` option to the burrito release config that controls which Mix environments are treated as production builds
- Defaults to `[:prod]` for full backward compatibility
- Fixes builds for projects using custom production environments like `:prod_cli`

## Problem

`is_prod/1` in `PackAndBuild` is hardcoded to check `Mix.env() == :prod`. Projects that use custom production environments (e.g. `:prod_cli` for building a CLI binary alongside a web app from the same codebase) always get `IS_PROD=0`, causing the Zig launcher to skip payload extraction and the release to silently fail to boot.

This is common when the same Elixir project needs different compile-time configs for different deployment targets (e.g. SQLite for CLI vs Postgres for web).

## Solution

```elixir
# In release config:
burrito: [
  prod_envs: [:prod, :prod_cli],
  targets: [...]
]
```

The `prod_envs` option accepts a list of atoms. When `Mix.env()` matches any entry, `IS_PROD` is set to `"1"`. The default `[:prod]` preserves existing behavior.

## Test plan

- [x] Verified `IS_PROD=1` in Zig build env with `prod_envs: [:prod, :prod_cli]`
- [x] Verified Burrito binary extracts payload and boots successfully
- [x] Verified default behavior unchanged (`:prod` still works without the option)

🤖 Generated with [Claude Code](https://claude.com/claude-code)