### PR TITLE
Stop Elixir's CLI consuming app arguments and halting the VM

### DIFF
--- a/lib/util/args.ex
+++ b/lib/util/args.ex
@@ -11,8 +11,18 @@ defmodule Burrito.Util.Args do
   """
   @spec get_arguments :: list(String.t())
   def get_arguments do
-    :init.get_plain_arguments() |> Enum.map(&to_string/1)
+    :init.get_plain_arguments()
+    |> Enum.map(&to_string/1)
+    |> strip_separator()
   end
+
+  # The wrapper passes `--no-halt --` after `-extra` to keep Elixir's CLI from
+  # halting the VM and from claiming the application's arguments. Neither is an
+  # argument, so drop them. Only this exact leading pair is matched, so an
+  # application that takes its own `--` still sees it.
+  defp strip_separator(["--no-halt", "--" | rest]), do: rest
+  defp strip_separator(["--" | rest]), do: rest
+  defp strip_separator(args), do: args
 
   @doc """
   Get the arguments from the CLI, regardless if run under Burrito or not.

--- a/src/erlang_launcher.zig
+++ b/src/erlang_launcher.zig
@@ -72,6 +72,19 @@ pub fn launch(io: Io, install_dir: []const u8, env_map: *std.process.Environ.Map
         "-config",
         config_sys_path,
         "-extra",
+        // These two are for Elixir's CLI, which runs via `-s elixir start_cli`
+        // above and reads everything after `-extra`.
+        //
+        // --no-halt: without it the CLI halts the VM once it finishes, killing
+        // any application that is meant to keep running.
+        //
+        // --: without it the CLI claims --version and --help for itself and
+        // treats the first remaining argument as a script path.
+        //
+        // Burrito.Util.Args strips both back off before the application sees
+        // its arguments.
+        "--no-halt",
+        "--",
     };
 
     // Cross-platform: build args once, set env, spawn child, wait for exit


### PR DESCRIPTION
Fixes #229.

1.6.0 split `"-s elixir start_cli"` from a single argv element into three. `erl` does not split argv elements, so the flag was never recognised before and `start_cli` never ran. Now it does, and it does what it is supposed to: claims `--version` and `--help`, treats the first remaining plain argument as a script path, and halts the VM when it finishes.

Two consequences for wrapped applications:

```
$ probe hello world
No file named hello

$ probe --version
Erlang/OTP 29 [erts-17.0.3] ...
Elixir 1.20.2 (compiled with Erlang/OTP 29)
```

and, with no arguments at all, an application that never halts exits about 1.3s after boot, which breaks servers and Phoenix applications.

## Change

Emit `--no-halt` and `--` after `-extra`, and strip them back off in `Burrito.Util.Args`.

`--no-halt` restores the pre-1.6.0 lifetime, `--` stops the CLI claiming arguments, and `start_cli` still runs, so whatever the split in #225 was made for is unaffected.

Reverting to the single joined element would also fix both, but only by making `start_cli` silently not run again.

## Verification

A 12-line application whose only dependency is burrito, built on macOS 26 arm64 with Zig 0.16.0, and on Linux arm64 in a container.

Arguments, before and after:

```
                        1.6.0                      patched
probe hello world       No file named hello        argv=["hello", "world"]
probe --version         Elixir 1.20.2 ...          argv=["--version"]
probe --help            Standalone options ...     argv=["--help"]
probe --transport stdio No file named --transport  argv=["--transport", "stdio"]
```

Lifetime, no arguments, application never halts:

| | result |
|---|---|
| 1.6.0 | exits after 1289ms, rc=0 |
| patched | still running at 12s, killed by `timeout` |

Not broken by the change:

- exit codes propagate (`System.halt(7)` gives 7)
- `maintenance directory` and `maintenance meta` work
- the EPIPE handling from #225 still terminates cleanly when piped into `head -3`, on both platforms
- an application passing its own `--` still receives it, since only the exact leading `--no-halt --` pair is stripped

Also exercised against a real application: an MCP server that takes `--transport` and `--port` and then runs indefinitely. On 1.6.0 it cannot start; with this change it parses its flags, completes a protocol handshake over stdio, serves a live tool call, and exits 0 when its client disconnects.

One note for the docs: `System.argv/0` is populated only once `start_cli` runs, which is after `Application.start/2`, so applications still need `Burrito.Util.Args`.